### PR TITLE
Add Direct/Raw pbsmrtpipe job type

### DIFF
--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/JobModels.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/JobModels.scala
@@ -242,6 +242,12 @@ object JobModels {
     def pbOptionId = toI("boolean")
   }
 
+  // Raw (aka) Direct Options. Minimal options used to call pbsmrtpipe
+  case class PbsmrtpipeDirectJobOptions(pipelineId: String,
+                                        entryPoints: Seq[BoundEntryPoint],
+                                        taskOptions: Seq[PipelineBaseOption],
+                                        workflowOptions: Seq[PipelineBaseOption])
+
   // pbsmrtpipe/smrtflow Pipelines
   case class PipelineTemplate(id: String,
                               name: String,

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/SecondaryJsonProtocols.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/SecondaryJsonProtocols.scala
@@ -1,6 +1,8 @@
 package com.pacbio.secondary.analysis.jobs
 
+import java.net.URI
 import java.util.UUID
+
 import com.pacbio.secondary.analysis.datasets.DataSetMetaTypes
 import com.pacbio.secondary.analysis.engine.EngineConfig
 import com.pacbio.secondary.analysis.jobs.JobModels._
@@ -220,8 +222,22 @@ trait PipelineTemplatePresetJsonProtocol extends DefaultJsonProtocol with Pipeli
       }
     }
   }
+}
+
+trait URIJsonProtocol extends DefaultJsonProtocol {
+
+  implicit object URIJsonProtocolFormat extends RootJsonFormat[URI] {
+    def write(x: URI) = JsString(x.toString)
+    def read(value: JsValue) = {
+      value match {
+        case JsString(x) => new URI(x)
+        case _ => deserializationError("Expected URI")
+      }
+    }
+  }
 
 }
+
 
 
 trait JobTypeSettingProtocol extends DefaultJsonProtocol
@@ -230,7 +246,7 @@ with UUIDJsonProtocol
 with JobStatesJsonProtocol
 with DataSetMetaTypesProtocol
 with PipelineTemplateJsonProtocol
-with PipelineTemplatePresetJsonProtocol {
+with PipelineTemplatePresetJsonProtocol with URIJsonProtocol {
 
 
   import JobModels._
@@ -255,7 +271,7 @@ with PipelineTemplatePresetJsonProtocol {
   implicit val pipelineTemplateViewRule = jsonFormat4(PipelineTemplateViewRule)
 
   // Job Options
-  //implicit val pbsmrtpipeJobOptionsFormat = jsonFormat5(PbSmrtPipeJobOptions)
+  implicit val directPbsmrtpipeJobOptionsFormat = jsonFormat4(PbsmrtpipeDirectJobOptions)
   implicit val simpleDevJobOptionsFormat = jsonFormat2(SimpleDevJobOptions)
   implicit val simpleDataTransferOptionsFormat = jsonFormat2(SimpleDataTransferOptions)
   implicit val movieMetadataToHdfSubreadOptionsFormat = jsonFormat2(MovieMetadataToHdfSubreadOptions)

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/jobtypes/DirectPbsmrtpipeJobType.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/jobtypes/DirectPbsmrtpipeJobType.scala
@@ -1,0 +1,202 @@
+package com.pacbio.secondary.smrtserver.services.jobtypes
+
+
+import java.io.File
+import java.net.{URI, URL}
+import java.nio.file.{Files, Path, Paths}
+import java.util.UUID
+
+import akka.actor.ActorRef
+import akka.pattern._
+import akka.util.Timeout
+import com.pacbio.common.actors.{UserServiceActor, UserServiceActorRefProvider}
+import com.pacbio.common.auth.{Authenticator, AuthenticatorProvider}
+import com.pacbio.common.dependency.Singleton
+import com.pacbio.common.logging.{LoggerFactory, LoggerFactoryProvider}
+import com.pacbio.common.models.LogMessageRecord
+import com.pacbio.common.services.PacBioServiceErrors.ResourceNotFoundError
+import com.pacbio.secondary.analysis.engine.CommonMessages.{CheckForRunnableJob, ImportDataStoreFile, ImportDataStoreFileByJobId}
+import com.pacbio.secondary.analysis.engine.EngineConfig
+import com.pacbio.secondary.analysis.jobs.{CoreJob, SecondaryJobProtocols}
+import com.pacbio.secondary.analysis.jobs.JobModels._
+import com.pacbio.secondary.analysis.jobtypes.PbSmrtPipeJobOptions
+import com.pacbio.secondary.analysis.pbsmrtpipe.{PbsmrtpipeEngineOptions, _}
+import com.pacbio.secondary.smrtlink.actors.JobsDaoActor._
+import com.pacbio.secondary.smrtlink.actors.{EngineManagerActorProvider, JobsDaoActorProvider}
+import com.pacbio.secondary.smrtlink.app.SmrtLinkConfigProvider
+import com.pacbio.secondary.smrtlink.models._
+import com.pacbio.secondary.smrtlink.services.jobtypes.{JobTypeService, ValidateImportDataSetUtils}
+import com.pacbio.secondary.smrtlink.services.JobManagerServiceProvider
+import com.pacbio.secondary.smrtserver.SmrtServerConstants
+import com.pacbio.secondary.smrtserver.models.SecondaryAnalysisJsonProtocols
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.io.{FileUtils, FilenameUtils}
+
+import scala.collection.JavaConversions._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+
+// For serialization magic. This is required for any serialization in spray to work.
+
+import spray.http._
+import spray.httpx.SprayJsonSupport._
+import spray.json._
+
+
+
+class DirectPbsmrtpipeJobType(dbActor: ActorRef,
+                               userActor: ActorRef,
+                               engineManagerActor: ActorRef,
+                               authenticator: Authenticator,
+                               loggerFactory: LoggerFactory,
+                               engineConfig: EngineConfig,
+                               pbsmrtpipeEngineOptions: PbsmrtpipeEngineOptions,
+                               serviceStatusHost: String,
+                               port: Int,
+                               commandTemplate: Option[CommandTemplate] = None)
+  extends JobTypeService with LazyLogging {
+
+  logger.info(s"Pbsmrtpipe job type with Pbsmrtpipe engine options $pbsmrtpipeEngineOptions")
+
+  import SecondaryAnalysisJsonProtocols._
+  import SmrtServerConstants._
+  import SecondaryJobProtocols.directPbsmrtpipeJobOptionsFormat
+
+  // Not thrilled with this name
+  val endpoint = "pbsmrtpipe-direct"
+  val description =
+    """
+      |Run a secondary analysis pbsmrtpipe job and by passing the File Resolver. Assumes files are on the Shared
+      |FileSystem.
+    """.stripMargin
+
+  val rootUpdateURL = new URL(s"http://$serviceStatusHost:$port/$ROOT_SERVICE_PREFIX/$SERVICE_PREFIX/jobs/pbsmrtpipe")
+
+  def toURL(baseURL: URL, uuid: UUID): URI = {
+    // there has to be a cleaner way to do this
+    new URI(s"${baseURL.getProtocol}://${baseURL.getHost}:${baseURL.getPort}${baseURL.getPath}/${uuid.toString}")
+  }
+
+  val routes =
+    pathPrefix(endpoint) {
+      pathEndOrSingleSlash {
+        get {
+          complete {
+            jobList(dbActor, userActor, endpoint)
+          }
+        } ~
+          post {
+            optionalAuthenticate(authenticator.jwtAuth) { authInfo =>
+              entity(as[PbsmrtpipeDirectJobOptions]) { ropts =>
+
+                val uuid = UUID.randomUUID()
+                logger.info(s"Attempting to create pbsmrtpipe Job ${uuid.toString} from service options $ropts")
+
+                logger.info(s"Pbsmrtpipe Service Opts $ropts")
+                val jsonSettings = ropts.toJson
+                val envPath = ""
+                val serviceUri = toURL(rootUpdateURL, uuid)
+
+                val opts = PbSmrtPipeJobOptions(
+                  ropts.pipelineId,
+                  ropts.entryPoints,
+                  ropts.taskOptions,
+                  ropts.workflowOptions,
+                  envPath,
+                  Option(serviceUri))
+
+                val coreJob = CoreJob(uuid, opts)
+                // Should this be exposed via POST ?
+                val name = "Direct Pbsmrtpipe Job"
+                // It might be useful for this to try to look up the files by path. For now this is fine.
+                val entryPoints: Option[Seq[EngineJobEntryPointRecord]] = None
+
+                val fx = (dbActor ? CreateJobType(
+                  uuid,
+                  name,
+                  s"pbsmrtpipe ${ropts.pipelineId}",
+                  endpoint,
+                  coreJob,
+                  entryPoints,
+                  jsonSettings.toString(),
+                  authInfo.map(_.login)
+                )).mapTo[EngineJob]
+
+                complete {
+                  created {
+                    fx
+                  }
+                }
+              }
+            }
+          }
+      } ~
+        sharedJobRoutes(dbActor, userActor)
+    } ~
+      path(endpoint / IntNumber / LOG_PREFIX) { id =>
+        post {
+          entity(as[LogMessageRecord]) { m =>
+            respondWithMediaType(MediaTypes.`application/json`) {
+              complete {
+                created {
+                  val sourceId = s"job::$id::${m.sourceId}"
+                  loggerFactory.getLogger(LOG_PB_SMRTPIPE_RESOURCE_ID, sourceId).log(m.message, m.level)
+                  Map("message" -> s"Successfully logged. $sourceId -> ${m.message}")
+                }
+              }
+            }
+          }
+        }
+      } ~
+      path(endpoint / JavaUUID / LOG_PREFIX) { id =>
+        post {
+          entity(as[LogMessageRecord]) { m =>
+            respondWithMediaType(MediaTypes.`application/json`) {
+              complete {
+                created {
+                  (dbActor ? GetJobByUUID(id)).mapTo[EngineJob].map { engineJob =>
+                    val sourceId = s"job::${engineJob.id}::${m.sourceId}"
+                    loggerFactory.getLogger(LOG_PB_SMRTPIPE_RESOURCE_ID, sourceId).log(m.message, m.level)
+                    // an "ok" message should
+                    Map("message" -> s"Successfully logged. $sourceId -> ${m.message}")
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+}
+
+trait DirectPbsmrtpipeJobTypeProvider {
+  this: JobsDaoActorProvider
+    with AuthenticatorProvider
+    with UserServiceActorRefProvider
+    with EngineManagerActorProvider
+    with LoggerFactoryProvider
+    with SmrtLinkConfigProvider
+    with JobManagerServiceProvider =>
+  val pbsmrtpipeDirectServiceJobType: Singleton[DirectPbsmrtpipeJobType] =
+    Singleton(() => new DirectPbsmrtpipeJobType(
+      jobsDaoActor(),
+      userServiceActorRef(),
+      engineManagerActor(),
+      authenticator(),
+      loggerFactory(),
+      jobEngineConfig(),
+      pbsmrtpipeEngineOptions(),
+      // When the host is "0.0.0.0", we need to try to resolve the analysis host so that jobs submitted to cluster
+      // resources have an endpoint to communicate back with. Note this is not complete, for other cases, such as
+      // localhost, they get what they get. For pbsmrtpipe tasks, the error should be clear (enough) in the services-uri
+      // in the pbscala.sh
+      //
+      // Note, that by design, the subprocess or cluster job doesn't need
+      // to communicate back to the host (the wrapper Actor will handle updating the final state). However, we want
+      // for status messages to be sent back to the Server
+      if (host() != "0.0.0.0") host() else java.net.InetAddress.getLocalHost.getCanonicalHostName,
+      port(),
+      cmdTemplate())).bindToSet(JobTypes)
+}


### PR DESCRIPTION
[Bug 33059] Added pbsmrtpipe "direct" job type by pass resolving of DataSet to Path.

- This is intended for internal testing and for pipelines that don't all have entry-points that are DataSet types.
- Want to get internal analysis pipelines running that have Condition JSON files types as inputs
- Need to do some refactoring to reduce the duplication.