### PR TITLE
Remove unhelpful initial Akka stdout logging

### DIFF
--- a/smrt-server-base/src/main/resources/application.conf
+++ b/smrt-server-base/src/main/resources/application.conf
@@ -14,7 +14,7 @@ akka {
   # Log level for the very basic logger activated during ActorSystem startup.
   # This logger prints the log messages to stdout (System.out).
   # Options: OFF, ERROR, WARNING, INFO, DEBUG
-  stdout-loglevel = "DEBUG"
+  stdout-loglevel = "ERROR"
 }
 
 # This needs to be deleted


### PR DESCRIPTION
@skinner @natechols @mpkocher 

Title says it all. Now you won't see those 3 unhelpful lines every time this one `application.conf` is loaded.

```bash
[DEBUG] [05/17/2016 12:26:58.398] [pool-1-thread-1] [EventStream] StandardOutLogger started
[DEBUG] [05/17/2016 12:26:58.759] [pool-1-thread-1] [EventStream(akka://SecondaryJobSpec)] logger log1-Slf4jLogger started
[DEBUG] [05/17/2016 12:26:58.760] [pool-1-thread-1] [EventStream(akka://SecondaryJobSpec)] Default Loggers started
```

I'm not aware of any helpful information coming from this logger. We could probably delete the line entirely.