### PR TITLE
SecondaryAnalysisApp CLI logging arg support

### DIFF
--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/appcomponents/SecondaryAnalysisApp.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/appcomponents/SecondaryAnalysisApp.scala
@@ -69,7 +69,7 @@ object SecondaryAnalysisServer extends App with BaseServer with SecondaryApi {
   override val host = providers.serverHost()
   override val port = providers.serverPort()
 
-  LoggerOptions.parse(args)
+  LoggerOptions.parseRequireFile(args)
 
   start
 }

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/appcomponents/SecondaryAnalysisApp.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/appcomponents/SecondaryAnalysisApp.scala
@@ -6,6 +6,7 @@ import com.pacbio.common.app.{BaseServer, BaseApi}
 import com.pacbio.common.dependency.{TypesafeSingletonReader, Singleton}
 import com.pacbio.common.logging.{LoggerFactoryProvider, LogResources}
 import com.pacbio.common.models.LogResourceRecord
+import com.pacbio.logging.LoggerOptions
 import com.pacbio.secondary.smrtlink.app.SmrtLinkProviders
 import com.pacbio.secondary.smrtlink.auth.SmrtLinkRolesInit
 import com.pacbio.secondary.smrtserver.services._
@@ -67,6 +68,8 @@ trait SecondaryApi extends BaseApi with SmrtLinkRolesInit with LazyLogging {
 object SecondaryAnalysisServer extends App with BaseServer with SecondaryApi {
   override val host = providers.serverHost()
   override val port = providers.serverPort()
+
+  LoggerOptions.parse(args)
 
   start
 }

--- a/smrt-server-base/src/main/scala/com/pacbio/common/app/BaseSmrtServerApp.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/app/BaseSmrtServerApp.scala
@@ -1,7 +1,6 @@
 package com.pacbio.common.app
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
+import java.lang.management.ManagementFactory
 import java.net.BindException
 
 import akka.actor.{ActorRefFactory, Props}
@@ -17,6 +16,7 @@ import com.pacbio.common.logging.LoggerFactoryImplProvider
 import com.pacbio.common.models.MimeTypeDetectors
 import com.pacbio.common.services._
 import com.pacbio.common.time.SystemClockProvider
+import com.pacbio.logging.LoggerOptions
 import com.typesafe.scalalogging.LazyLogging
 import spray.can.Http
 import spray.routing.Route
@@ -192,6 +192,8 @@ object BaseSmrtServer extends App with BaseServer with BaseApi {
   override val port = providers.serverPort()
 
   override def startup(): Unit = providers.cleanupScheduler().scheduleAll()
+
+  LoggerOptions.parse(args)
 
   start
 }

--- a/smrt-server-base/src/main/scala/com/pacbio/common/app/BaseSmrtServerApp.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/app/BaseSmrtServerApp.scala
@@ -193,7 +193,7 @@ object BaseSmrtServer extends App with BaseServer with BaseApi {
 
   override def startup(): Unit = providers.cleanupScheduler().scheduleAll()
 
-  LoggerOptions.parse(args)
+  LoggerOptions.parseRequireFile(args)
 
   start
 }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/app/SmrtLinkApp.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/app/SmrtLinkApp.scala
@@ -81,7 +81,7 @@ object SmrtLinkSmrtServer extends App with BaseServer with SmrtLinkApi {
   override val host = providers.serverHost()
   override val port = providers.serverPort()
 
-  LoggerOptions.parse(args)
+  LoggerOptions.parseRequireFile(args)
 
   start
 }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/app/SmrtLinkApp.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/app/SmrtLinkApp.scala
@@ -11,6 +11,7 @@ import com.pacbio.secondary.smrtlink.database.DatabaseRunDaoProvider
 import com.pacbio.secondary.smrtlink.models.DataModelParserImplProvider
 import com.pacbio.secondary.smrtlink.services.jobtypes.{MockPbsmrtpipeJobTypeProvider, MergeDataSetServiceJobTypeProvider, ImportDataSetServiceTypeProvider}
 import com.pacbio.secondary.smrtlink.services._
+import com.pacbio.logging.LoggerOptions
 import com.typesafe.scalalogging.LazyLogging
 import spray.servlet.WebBoot
 
@@ -79,6 +80,8 @@ trait SmrtLinkApi extends BaseApi with SmrtLinkRolesInit with LazyLogging {
 object SmrtLinkSmrtServer extends App with BaseServer with SmrtLinkApi {
   override val host = providers.serverHost()
   override val port = providers.serverPort()
+
+  LoggerOptions.parse(args)
 
   start
 }

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
@@ -58,7 +58,8 @@ object LoggerOptions {
   }
 
   def parseRequireFile(args: Seq[String]): Unit = {
-    if (!args.contains("--logfile") && !args.contains("-h")) {
+    val requireOne = Set("--logfile", "--debug", "-h")
+    if (args.filter(requireOne).isEmpty) {
       println("You must set the logger output with a --logfile parameter")
       println("  e.g.")
       println("      java -jar my_code.jar --logfile example_file.log")

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
@@ -45,6 +45,9 @@ object LoggerOptions {
     */
   def parse(args: Seq[String]): Unit = {
     val parser = new OptionParser[LoggerConfig]("./app_with_logging") {
+      // Don't complain about args such as -jar used via command-line server execution
+      override def errorOnUnknownArgument = false
+      override def showUsageOnError = false
       note("This is an app that supports PacBio logging flags. ")
 
       opt[Unit]('h', "help") action { (x, c) =>

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
@@ -44,9 +44,26 @@ object LoggerOptions {
     * @param args Command line arguments
     */
   def parse(args: Seq[String]): Unit = {
-    val parser = new OptionParser[LoggerConfig]("Logger Default") {
+    val parser = new OptionParser[LoggerConfig]("./app_with_logging") {
+      note("This is an app that supports PacBio logging flags. ")
+
+      opt[Unit]('h', "help") action { (x, c) =>
+        showUsage
+        sys.exit(0)
+      } text "Show Options and exit"
+
       LoggerOptions.add(this)
     }
     parser.parse(args, new LoggerConfig(){})
+  }
+
+  def parseRequireFile(args: Seq[String]): Unit = {
+    if (!args.contains("--logfile") && !args.contains("-h")) {
+      println("You must set the logger output with a --logfile parameter")
+      println("  e.g.")
+      println("      java -jar my_code.jar --logfile example_file.log")
+      System.exit(1)
+    }
+    parse(args)
   }
 }

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
@@ -37,4 +37,16 @@ object LoggerOptions {
       c.configure(x, c.logFile, c.debug, c.logLevel)
     } text "Override all logger config with the given logback.xml file."
   }
+
+  /**
+    * Helper method for cases where an App doesn't otherwise use scopt parsing
+    *
+    * @param args Command line arguments
+    */
+  def parse(args: Seq[String]): Unit = {
+    val parser = new OptionParser[LoggerConfig]("Logger Default") {
+      LoggerOptions.add(this)
+    }
+    parser.parse(args, new LoggerConfig(){})
+  }
 }


### PR DESCRIPTION
@skinner @mpkocher 

Fixes #55

Adds command-line argument parsing for logging to the servers noted here https://github.com/PacificBiosciences/smrtflow/issues/55#issuecomment-219824672

The server code didn't use `scopt`; however, it is an `App` entry point that has CLI args. I added a util method so that if logging options are passed to the command line, they'll be used. This means that command line `--logfile` and `--loglevel` flags can now be used instead of a `logback.xml` file plus a properties file to config the log file and log level.

e.g.

```bash
java -jar target/scala-2.11/smrt-server-analysis*.jar --logfile /tmp/my_file.log --loglevel ERROR
```

And `-h` still works.

```
Usage: ./app_with_logging [options]

This is an app that supports PacBio logging flags. 
  -h | --help
        Show Options and exit
  --debug
        If true, log output will be displayed to the console. Default is false.
  --loglevel <value>
        Level for logging: "ERROR", "WARN", "DEBUG", or "INFO". Default is "ERROR"
  --logfile <value>
        File for log output. Default is "."
  --logback <value>
        Override all logger config with the given logback.xml file.
```

### Require Log File
These servers should have a log file specified during runtime. I added a utility method named `parseRequireFile` so that by default the code will not run without a log file. 

```
# Old way the code was run. Relied on config files that no longer exist.
java -jar target/scala-2.11/smrt-server-analysis*.jar

You must set the logger output with a --logfile parameter
  e.g.
      java -jar my_code.jar --logfile example_file.log
```

We can use `/dev/null` for dev work, if you don't want to log to a file.