### PR TITLE
Lazy make needed  `db` dir

### DIFF
--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -36,8 +36,11 @@ class Dal(val dbURI: String) {
   val flyway = new Flyway() {
     override def migrate(): Int = {
       // lazy make file database dir as needed
-      val file = scala.reflect.io.File(dbURI.stripPrefix("jdbc:sqlite:"))
-      if (file.parent != null && !file.parent.exists) file.parent.createDirectory()
+      val file = Paths.get(dbURI.stripPrefix("jdbc:sqlite:"))
+      if (file.getParent != null) {
+        val dir = file.getParent.toFile
+        if (!dir.exists()) dir.mkdirs()
+      }
 
       return super.migrate()
     }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -28,8 +28,9 @@ import scala.language.postfixOps
 import scala.slick.driver.SQLiteDriver.simple._
 import scala.slick.jdbc.meta.MTable
 import scala.util.{Failure, Success, Try}
-
 import org.flywaydb.core.Flyway
+
+import scala.reflect.io.Directory
 
 
 // TODO(smcclellan): Move this class into the c.p.s.s.database package? Or eliminate it?
@@ -932,6 +933,10 @@ with DataSetStore {
   var _runnableJobs = mutable.Map[UUID, RunnableJobWithId]()
 
   def initializeDb(): Unit = {
+    // lazy make ./db as needed
+    val dir = Directory("db")
+    if (!dir.exists) dir.createDirectory()
+
     dal.flyway.migrate()
   }
 }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -35,8 +35,8 @@ import org.flywaydb.core.Flyway
 class Dal(val dbURI: String) {
   val flyway = new Flyway() {
     override def migrate(): Int = {
-      // lazy make dev `db` database dir as needed. intended only for dev work
-      if (dbURI == "jdbc:sqlite:db/analysis_services.db") {
+      // lazy make directories as needed for sqlite
+      if (dbURI.startsWith("jdbc:sqlite:")) {
         val file = Paths.get(dbURI.stripPrefix("jdbc:sqlite:"))
         if (file.getParent != null) {
           val dir = file.getParent.toFile

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -35,11 +35,13 @@ import org.flywaydb.core.Flyway
 class Dal(val dbURI: String) {
   val flyway = new Flyway() {
     override def migrate(): Int = {
-      // lazy make file database dir as needed
-      val file = Paths.get(dbURI.stripPrefix("jdbc:sqlite:"))
-      if (file.getParent != null) {
-        val dir = file.getParent.toFile
-        if (!dir.exists()) dir.mkdirs()
+      // lazy make dev `db` database dir as needed. intended only for dev work
+      if (dbURI == "jdbc:sqlite:db/analysis_services.db") {
+        val file = Paths.get(dbURI.stripPrefix("jdbc:sqlite:"))
+        if (file.getParent != null) {
+          val dir = file.getParent.toFile
+          if (!dir.exists()) dir.mkdirs()
+        }
       }
 
       return super.migrate()
@@ -374,7 +376,8 @@ trait JobDataStore extends JobEngineDaoComponent with LazyLogging {
 
   /**
    * This is the new interface will replace the original createJob
-   * @param uuid UUID
+    *
+    * @param uuid UUID
    * @param name Name of job
    * @param description This is really a comment. FIXME
    * @param jobTypeId String of the job type identifier. This should be consistent with the
@@ -478,7 +481,8 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
 
   /**
    * Importing of DataStore File by Job Int Id
-   * @param ds
+    *
+    * @param ds
    * @param jobId
    * @return
    */
@@ -503,7 +507,8 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
 
   /**
    * Generic Importing of DataSet by type and Path to dataset file
-   * @param dataSetMetaType
+    *
+    * @param dataSetMetaType
    * @param spath
    * @param jobId
    * @param userId


### PR DESCRIPTION
Fixes #58 

I'm not sure if this is the ideal long-term fix, but it makes the code work as expected when running the code as noted in #58. The problematic case was if you lacked a `db` directory. Without manually making it, the code would error and exit.