### PR TITLE
Added port parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,6 @@ def PacBioProject(name: String): Project = (
       "com.github.fommil" %% "spray-json-shapeless" % "1.2.0",
       "org.scalaj" %% "scalaj-http" % "1.1.5",
       "org.flywaydb" % "flyway-core" % "4.0",
-      "com.github.tototoshi" %% "scala-csv" % "1.3.1",
       "com.lihaoyi" % "ammonite-repl" % "0.5.7" % "test" cross CrossVersion.full
     )
     )

--- a/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/IOUtils.scala
+++ b/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/IOUtils.scala
@@ -5,7 +5,6 @@ import java.nio.file.Path
 import scala.io.Source
 
 import com.pacbio.secondaryinternal.models._
-import com.github.tototoshi.csv._
 
 
 object IOUtils {
@@ -15,9 +14,15 @@ object IOUtils {
 
 
   def parseConditionCsv(sx: Source): Seq[ServiceCondition] = {
-    val reader = CSVReader.open(sx)
-    val datum = reader.allWithHeaders()
-    // FIXME(mpkocher)(2016-4-17) Add format for the host of "smrtlink-beta:9999"
-    datum.map(x => ServiceCondition(x("condId"), x("host"), 8081, x("jobId").toInt))
+    sx.getLines.drop(1).toSeq.map(x => parseLine(x.split(",").map(_.trim):_*))
+  }
+
+  def parseLine(args: String*): ServiceCondition = {
+    parseLine(args(0), args(1), args(2).toInt)
+  }
+
+  def parseLine(condId : String, host : String, jobId : Int): ServiceCondition = {
+    ServiceCondition(condId, host.split(":")(0), if (!host.contains(":")) 8081 else host.split(":")(1).toInt, jobId)
+
   }
 }

--- a/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/IOUtils.scala
+++ b/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/IOUtils.scala
@@ -4,7 +4,7 @@ import java.nio.file.Path
 
 import scala.io.Source
 
-import com.pacbio.secondaryinternal.models._
+import com.pacbio.secondaryinternal.models.ServiceCondition
 
 
 object IOUtils {

--- a/smrt-server-analysis-internal/src/test/scala/IOUtilsSpec.scala
+++ b/smrt-server-analysis-internal/src/test/scala/IOUtilsSpec.scala
@@ -13,7 +13,7 @@ class IOUtilsSpec extends Specification {
   }
   val xs =
     """condId,host,jobId
-      |a,smrtlink-a:8081,1
+      |a,smrtlink-a:9999,1
       |a,smrtlink-b,2
       |b,smrtlink-c,3""".stripMargin
 
@@ -31,6 +31,16 @@ class IOUtilsSpec extends Specification {
       val records = IOUtils.parseConditionCsv(scala.io.Source.fromString(xs))
       println(records)
       records.length must beEqualTo(3)
+      // Check one example with port parsing
+      records(0).id must beEqualTo("a")
+      records(0).host must beEqualTo("smrtlink-a")
+      records(0).port must beEqualTo(9999)
+      records(0).jobId must beEqualTo(1)
+      // Check one example with default port
+      records(2).id must beEqualTo("b")
+      records(2).host must beEqualTo("smrtlink-c")
+      records(2).port must beEqualTo(8081)
+      records(2).jobId must beEqualTo(3)
     }
   }
 

--- a/smrt-server-analysis-internal/src/test/scala/IOUtilsSpec.scala
+++ b/smrt-server-analysis-internal/src/test/scala/IOUtilsSpec.scala
@@ -2,7 +2,6 @@ import org.specs2.mutable.Specification
 
 import java.nio.file.Paths
 
-import com.pacbio.secondaryinternal.models._
 import com.pacbio.secondaryinternal.IOUtils
 
 class IOUtilsSpec extends Specification {


### PR DESCRIPTION
I came across this TODO while reading some of the internal code. Added a test to show it works as expected. Previously, the test had an example with a port but didn't assert it parsed correctly. Now it does.

```bash
sbt "smrt-server-analysis-internal/testOnly IOUtilsSpec"
```

The change also allowed for dropping a dependency.