### PR TITLE
Added scoverage plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "1.1.1")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")


### PR DESCRIPTION
This adds code coverage support via [scoverage](https://github.com/scoverage/sbt-scoverage). Handy to gauge if tests are lacking or if code is unused by known integration tests. Also means we can add [coveralls.io](https://coveralls.io/) for free, including GH hooks.

```bash
sbt clean coverage test coverageReport
```

Then lookup the HTML report in the respective `target/` subdir. e.g. `smrtflow/smrt-server-analysis-internal/target/scala-2.11/scoverage-report/index.html`

<img width="936" alt="screen shot 2016-05-24 at 11 23 30 am" src="https://cloud.githubusercontent.com/assets/855834/15509623/1b5e7c68-21a2-11e6-973a-470422094f11.png">

And here is a class that I added a test for in #77 

<img width="940" alt="screen shot 2016-05-24 at 11 24 19 am" src="https://cloud.githubusercontent.com/assets/855834/15509652/37eac5ee-21a2-11e6-910d-831bb8997d91.png">
