### PR TITLE
Coveralls (Code Coverage SaaS)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "1.1.1")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")


### PR DESCRIPTION
This adds the [Coveralls.io](https://coveralls.io/github/PacificBiosciences/smrtflow) plugin so that `smrtflow` code coverage reports can be hosted. The `scoverage` docs [note how to setup coveralls.](https://github.com/scoverage/sbt-coveralls).

Right now, I'm exporting the coveralls key manually. If we add this to CI we'll need to add the secret.

```bash
export COVERALLS_REPO_TOKEN=...
```

Then you run coverage #78, `coverageAggregate` and `coveralls`.

```bash
sbt sbt clean coverage test coverageAggregate coveralls
```

Results are posted in the UI. GH hooks can also be added to post in PR threads.

<img width="902" alt="screen shot 2016-05-24 at 12 01 10 pm" src="https://cloud.githubusercontent.com/assets/855834/15510908/6778e5ac-21a7-11e6-997d-a1abd4ab1e50.png">

<img width="928" alt="screen shot 2016-05-24 at 12 01 47 pm" src="https://cloud.githubusercontent.com/assets/855834/15510936/860ddcc0-21a7-11e6-9b62-fdfddfcaff32.png">

And it shows per-file break downs of conditionals.
<img width="913" alt="screen shot 2016-05-24 at 12 07 01 pm" src="https://cloud.githubusercontent.com/assets/855834/15511086/16123136-21a8-11e6-9059-cc1a8e91fcf9.png">



