### PR TITLE
Ignore IntelliJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ db/*
 # ensime-specific
 .ensime
 .ensime_cache
+
+# IntelliJ
+.idea/*


### PR DESCRIPTION
Helps keep git from messing with IntelliJ files. Also helps prevents you project config from somehow getting in the repo.