### PR TITLE
Default --debug for App classes

### DIFF
--- a/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/SecondaryInternalAnalysis.scala
+++ b/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/SecondaryInternalAnalysis.scala
@@ -99,7 +99,7 @@ object SecondaryAnalysisInternalServer extends App
   override val port = providers.serverPort()
   println(s"serverPort: ${providers.serverPort()}")
 
-  LoggerOptions.parseRequireFile(args)
+  LoggerOptions.parseAddDebug(args)
 
   start
 }

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/appcomponents/SecondaryAnalysisApp.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/appcomponents/SecondaryAnalysisApp.scala
@@ -69,7 +69,7 @@ object SecondaryAnalysisServer extends App with BaseServer with SecondaryApi {
   override val host = providers.serverHost()
   override val port = providers.serverPort()
 
-  LoggerOptions.parseRequireFile(args)
+  LoggerOptions.parseAddDebug(args)
 
   start
 }

--- a/smrt-server-base/src/main/scala/com/pacbio/common/app/BaseSmrtServerApp.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/app/BaseSmrtServerApp.scala
@@ -193,7 +193,7 @@ object BaseSmrtServer extends App with BaseServer with BaseApi {
 
   override def startup(): Unit = providers.cleanupScheduler().scheduleAll()
 
-  LoggerOptions.parseRequireFile(args)
+  LoggerOptions.parseAddDebug(args)
 
   start
 }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/app/SmrtLinkApp.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/app/SmrtLinkApp.scala
@@ -81,7 +81,7 @@ object SmrtLinkSmrtServer extends App with BaseServer with SmrtLinkApi {
   override val host = providers.serverHost()
   override val port = providers.serverPort()
 
-  LoggerOptions.parseRequireFile(args)
+  LoggerOptions.parseAddDebug(args)
 
   start
 }

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
@@ -60,14 +60,9 @@ object LoggerOptions {
     parser.parse(args, new LoggerConfig(){})
   }
 
-  def parseRequireFile(args: Seq[String]): Unit = {
+  def parseAddDebug(args: Seq[String]): Unit = {
     val requireOne = Set("--logfile", "--debug", "-h")
-    if (args.filter(requireOne).isEmpty) {
-      println("You must set the logger output with a --logfile parameter")
-      println("  e.g.")
-      println("      java -jar my_code.jar --logfile example_file.log")
-      System.exit(1)
-    }
-    parse(args)
+    val v = if (args.filter(requireOne).isEmpty) args :+ "--debug" else args
+    parse(v)
   }
 }


### PR DESCRIPTION
Fixes #90

CC @skinner @mpkocher 

Switched default `App` use of logging to have `--debug` specified. There is no need to manually add the flag. You can still use the `--logfile` and other logging params. 

Tests pass

```
sbt clean test
```

Running the server by hand with no extra args now defaults to debug as expected.

```
# run manually
sbt smrt-server-analysis/assembly
java -jar smrt-server-analysis/target/scala-2.11/smrt-server-analysis*.jar

2016-05-25  INFO [main] c.p.s.s.a.SecondaryAnalysisServer$ - Starting App
2016-05-25  INFO [main] c.p.s.s.a.SecondaryAnalysisServer$ - Java Version: 1.8.0_92
2016-05-25  INFO [main] c.p.s.s.a.SecondaryAnalysisServer$ - Java Home: /Library/Java/JavaVirtualMachines/jdk1.8.0_92.jdk/Contents/Home/jre
2016-05-25  INFO [main] c.p.s.s.a.SecondaryAnalysisServer$ - Java Args: 
2016-05-25  INFO [smrtlink-analysis-server-akka.actor.default-dispatcher-2] a.e.s.Slf4jLogger - Slf4jLogge
...
```

And I also checked that `--logfile` still works as intended.