### PR TITLE
`None` as the default PacBioComponentManifest dependency arg

### DIFF
--- a/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/services/LimsResolverService.scala
+++ b/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/services/LimsResolverService.scala
@@ -2,7 +2,6 @@ package com.pacbio.secondaryinternal.services
 
 import com.pacbio.common.dependency.Singleton
 import com.pacbio.common.models.PacBioComponentManifest
-import com.pacbio.common.models.PacBioComponentManifest
 import com.pacbio.secondaryinternal.BaseInternalMicroService
 import com.pacbio.secondaryinternal.Constants
 import com.pacbio.secondaryinternal.InternalAnalysisJsonProcotols
@@ -31,7 +30,7 @@ class LimsResolverService(dao: LimsDao) extends BaseInternalMicroService {
 
   val manifest = PacBioComponentManifest(toServiceId("smrtlink_resource_resolver"),
     "SMRT Link Resource Resolver", "0.1.0",
-    "Service to resolve job paths from job ids using SMRT Link Resources id.", None)
+    "Service to resolve job paths from job ids using SMRT Link Resources id.")
 
   val DEFAULT_MAX_RESULTS = 5000
   val PREFIX = "resolvers"

--- a/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/services/ReferenceSetResolverService.scala
+++ b/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/services/ReferenceSetResolverService.scala
@@ -33,7 +33,7 @@ class ReferenceSetResolverService(dao: ReferenceResourceDao) extends BaseInterna
 
   val manifest = PacBioComponentManifest(toServiceId("reference_resolver"),
     "SMRT Link Reference Resolver", "0.1.0",
-    "Service to Globally resolve ReferenceSets by 'id', such as 'lambdaNEB'", None)
+    "Service to Globally resolve ReferenceSets by 'id', such as 'lambdaNEB'")
 
   val DEFAULT_MAX_RESULTS = 5000
   val PREFIX = "resolvers"

--- a/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/services/SmrtLinkResourceService.scala
+++ b/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/services/SmrtLinkResourceService.scala
@@ -26,7 +26,7 @@ class SmrtLinkResourceService(dao: SmrtLinkResourceDao) extends BaseInternalMicr
 
   val manifest = PacBioComponentManifest(toServiceId("smrtlink_resource_resolver"),
     "SMRT Link Resource Resolver", "0.1.0",
-    "Service to resolve job paths from job ids using SMRT Link Resources id.", None)
+    "Service to resolve job paths from job ids using SMRT Link Resources id.")
 
   val PREFIX = "smrtlink-systems"
 

--- a/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/services/jobtypes/ConditionJobType.scala
+++ b/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/services/jobtypes/ConditionJobType.scala
@@ -22,7 +22,6 @@ import com.pacbio.common.actors.{ActorSystemProvider, UserServiceActorRefProvide
 import com.pacbio.common.auth.AuthenticatorProvider
 import com.pacbio.common.dependency.Singleton
 import com.pacbio.common.logging.LoggerFactoryProvider
-import com.pacbio.common.models.PacBioComponentManifest
 import com.pacbio.secondary.analysis.constants.FileTypes
 import com.pacbio.secondary.analysis.jobs.CoreJob
 import com.pacbio.secondary.analysis.jobs.JobModels.{BoundEntryPoint, EngineJob, PipelineBaseOption, PipelineStrOption}

--- a/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/tempbase/package.scala
+++ b/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/tempbase/package.scala
@@ -81,7 +81,7 @@ class ManifestService(services: ServiceComposer) extends PacBioService with Defa
   val manifest = PacBioComponentManifest(
     toServiceId("service_manifests"),
     "Status Service",
-    "0.2.0", "Subsystem Manifest Service", None)
+    "0.2.0", "Subsystem Manifest Service")
 
   val routes =
     path("services" / "manifests") {

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/DataSetImportService.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/DataSetImportService.scala
@@ -46,8 +46,7 @@ class DataSetImportService(dbActor: ActorRef) extends JobsBaseMicroService {
   val manifest = PacBioComponentManifest(
     toServiceId("secondary.scan_importer.dataset"),
     "Secondary DataSet Importing Service", "0.2.0",
-    "Secondary DataSet Import/Scan Service",
-    None)
+    "Secondary DataSet Import/Scan Service")
 
   val routes =
     pathPrefix(basePrefix) {

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/PipelineTemplateViewRulesService.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/PipelineTemplateViewRulesService.scala
@@ -24,7 +24,7 @@ class PipelineTemplateViewRulesService(ptvs: Seq[PipelineTemplateViewRule]) exte
   val manifest = PacBioComponentManifest(toServiceId("secondary.pipeline_template_view_rules"),
     "Pipeline Template View Rules Service Service",
     "0.1.0",
-    "Analysis PiplineTemplate View RulesService", None)
+    "Analysis PiplineTemplate View RulesService")
 
   val ptvrs = PipelineTemplateViewRulesResourceLoader.loadResources
 

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/ReportViewRulesService.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/ReportViewRulesService.scala
@@ -24,7 +24,7 @@ class ReportViewRulesService(ptvrs: Seq[ReportViewRule]) extends JobsBaseMicroSe
   val manifest = PacBioComponentManifest(toServiceId("secondary.report_view_rules"),
     "Report View Rules Service Service",
     "0.1.0",
-    "Analysis Report View Rules Service", None)
+    "Analysis Report View Rules Service")
 
   val routes =
     pathPrefix(PTVR_PREFIX) {

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/ResolvedPipelineTemplateService.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/ResolvedPipelineTemplateService.scala
@@ -25,7 +25,7 @@ class ResolvedPipelineTemplateService(dao: PipelineTemplateDao) extends JobsBase
   val manifest = PacBioComponentManifest(toServiceId("resolved_pipeline_templates"),
     "New Pipeline Template Service",
     "0.1.0",
-    "Resolved Pipeline Templates Service", None)
+    "Resolved Pipeline Templates Service")
 
   val PIPELINE_TEMPLATE_PREFIX = "resolved-pipeline-templates"
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/models/JsonProtocols.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/models/JsonProtocols.scala
@@ -143,7 +143,7 @@ trait PacBioComponentManifestProtocol extends DefaultJsonProtocol with NullOptio
     def read(value: JsValue) = {
       value.asJsObject.getFields("id", "name", "version", "description", "dependencies") match {
         case Seq(JsString(id), JsString(name), JsString(version), JsString(description), JsString(dependencies)) =>
-          PacBioComponentManifest(id, name, version, description, None)
+          PacBioComponentManifest(id, name, version, description)
         case _ => throw new DeserializationException("PacbioManifest expected.")
       }
     }

--- a/smrt-server-base/src/main/scala/com/pacbio/common/models/Models.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/models/Models.scala
@@ -58,7 +58,7 @@ case class SubsystemConfig(id: String, name: String, startedAt: JodaDateTime)
 // The Name of components/dependencies
 case class PacBioComponent(id: String, version: String)
 
-case class PacBioComponentManifest(id: String, name: String, version: String, description: String, dependencies: Option[Seq[PacBioComponent]] = None)
+case class PacBioComponentManifest(id: String, name: String, version: String, description: String, dependencies: Option[Seq[PacBioComponent]] = Nil)
 
 case class ServiceComponent(id: String, typeId: String, version: String)
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/models/Models.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/models/Models.scala
@@ -58,7 +58,7 @@ case class SubsystemConfig(id: String, name: String, startedAt: JodaDateTime)
 // The Name of components/dependencies
 case class PacBioComponent(id: String, version: String)
 
-case class PacBioComponentManifest(id: String, name: String, version: String, description: String, dependencies: Option[Seq[PacBioComponent]] = Nil)
+case class PacBioComponentManifest(id: String, name: String, version: String, description: String, dependencies: Seq[PacBioComponent] = Nil)
 
 case class ServiceComponent(id: String, typeId: String, version: String)
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/models/Models.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/models/Models.scala
@@ -58,7 +58,7 @@ case class SubsystemConfig(id: String, name: String, startedAt: JodaDateTime)
 // The Name of components/dependencies
 case class PacBioComponent(id: String, version: String)
 
-case class PacBioComponentManifest(id: String, name: String, version: String, description: String, dependencies: Option[Seq[PacBioComponent]])
+case class PacBioComponentManifest(id: String, name: String, version: String, description: String, dependencies: Option[Seq[PacBioComponent]] = None)
 
 case class ServiceComponent(id: String, typeId: String, version: String)
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/AbstractFilesService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/AbstractFilesService.scala
@@ -53,8 +53,7 @@ abstract class AbstractFilesService(mimeTypes: MimeTypes)(implicit val actorSyst
     toServiceId(serviceBaseId),
     serviceName,
     serviceVersion,
-    serviceDescription,
-    dependencies = None)
+    serviceDescription)
 
   // TODO(smcclellan): Add auth
   override lazy val routes =

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/CleanupService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/CleanupService.scala
@@ -29,7 +29,7 @@ class CleanupService(cleanupActor: ActorRef, authenticator: Authenticator)
   val manifest = PacBioComponentManifest(
     toServiceId("cleanup"),
     "Subsystem Cleanup Service",
-    "0.2.0", "Subsystem Cleanup Service", None)
+    "0.2.0", "Subsystem Cleanup Service")
 
   val routes =
     pathPrefix("cleanup" / "jobs") {

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/ConfigService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/ConfigService.scala
@@ -25,7 +25,7 @@ class ConfigService extends PacBioService {
   val manifest = PacBioComponentManifest(
     toServiceId("config"),
     "Config Service",
-    "0.1.0", "Subsystem Config Service", Some(components))
+    "0.1.0", "Subsystem Config Service", components)
 
   val routes = pathPrefix("config") {
     pathEnd {

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/HealthService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/HealthService.scala
@@ -30,7 +30,7 @@ class HealthService(healthActor: ActorRef, authenticator: Authenticator)
   val manifest = PacBioComponentManifest(
     toServiceId("health"),
     "Subsystem Health Service",
-    "0.2.0", "Subsystem Health Service", Some(components))
+    "0.2.0", "Subsystem Health Service", components)
 
   val healthServiceName = "health"
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/LogService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/LogService.scala
@@ -32,7 +32,7 @@ class LogService(logActor: ActorRef, authenticator: Authenticator)
   val manifest = PacBioComponentManifest(
     toServiceId("log"),
     "Subsystem Logging Service",
-    "0.3.0", "Subsystem Logging Service", None)
+    "0.3.0", "Subsystem Logging Service")
 
   val logServiceName = "loggers"
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/ManifestService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/ManifestService.scala
@@ -13,7 +13,7 @@ class ManifestService(manifests: Set[PacBioComponentManifest]) extends PacBioSer
   val manifest = PacBioComponentManifest(
     toServiceId("service_manifests"),
     "Status Service",
-    "0.2.0", "Subsystem Manifest Service", None)
+    "0.2.0", "Subsystem Manifest Service")
 
   val routes =
     path("services" / "manifests") {
@@ -44,7 +44,7 @@ class ManifestServicex(services: ServiceComposer) extends PacBioService with Def
   val manifest = PacBioComponentManifest(
     toServiceId("service_manifests"),
     "Status Service",
-    "0.2.0", "Subsystem Manifest Service", None)
+    "0.2.0", "Subsystem Manifest Service")
 
   val routes =
     path("services" / "manifests") {

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/StatusService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/StatusService.scala
@@ -27,7 +27,7 @@ class StatusService(statusActor: ActorRef) extends PacBioService {
   val manifest = PacBioComponentManifest(
     toServiceId("status"),
     "Status Service",
-    "0.2.0", "Subsystem Status Service", None)
+    "0.2.0", "Subsystem Status Service")
 
   val statusServiceName = "status"
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/SubSystemComponentService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/SubSystemComponentService.scala
@@ -14,7 +14,7 @@ class SubSystemComponentService extends PacBioService with AppConfig {
   val manifest = PacBioComponentManifest(
     toServiceId("components"),
     "Subsystem Component Service",
-    "0.2.0", "Subsystem Component Service", None)
+    "0.2.0", "Subsystem Component Service")
 
   val componentServiceName = "components"
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/SubSystemResourceService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/SubSystemResourceService.scala
@@ -18,7 +18,7 @@ class SubSystemResourceService extends PacBioService {
   val manifest = PacBioComponentManifest(
     toServiceId("subsystem_resources"),
     "Subsystem Resources Service",
-    "0.2.0", "Subsystem Resources Service", None)
+    "0.2.0", "Subsystem Resources Service")
 
   val exampleResource = SubsystemResource(UUID.randomUUID, "MyDisplayName", "0.1.2",
     "/subsystem_resources", "/docs/user/subsystem", "/docs/api/subsystem", JodaDateTime.now, JodaDateTime.now)

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/UserService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/UserService.scala
@@ -33,7 +33,7 @@ class UserService(userActor: ActorRef, authenticator: Authenticator)
   val manifest = PacBioComponentManifest(
     toServiceId("user"),
     "Subsystem User Service",
-    "0.2.0", "Subsystem Health Service", Some(components))
+    "0.2.0", "Subsystem Health Service", components)
 
   val userServiceName = "user"
 

--- a/smrt-server-base/src/test/scala/PacbioJsonProtocolSpec.scala
+++ b/smrt-server-base/src/test/scala/PacbioJsonProtocolSpec.scala
@@ -28,7 +28,7 @@ class PacbioJsonProtocolSpec extends Specification {
     }
     "Manifest serialization with Components" in {
       val components = Seq(PacBioComponent("pacbio.tools.blasr", "0.2.1"), PacBioComponent("pacbio.tools.pbfilter", "0.2.1"))
-      val m = PacBioComponentManifest("myid", "myname", "0.1.1", "description", Option(components))
+      val m = PacBioComponentManifest("myid", "myname", "0.1.1", "description", components)
       m.id must beEqualTo("myid")
       val x = m.toJson
       println(x)

--- a/smrt-server-base/src/test/scala/PacbioJsonProtocolSpec.scala
+++ b/smrt-server-base/src/test/scala/PacbioJsonProtocolSpec.scala
@@ -20,7 +20,7 @@ class PacbioJsonProtocolSpec extends Specification {
       m.severity must beEqualTo(HealthSeverity.ALERT)
     }
     "Manifest serialization" in {
-      val m = PacBioComponentManifest("myid", "myname", "0.1.1", "description", None)
+      val m = PacBioComponentManifest("myid", "myname", "0.1.1", "description")
       m.id must beEqualTo("myid")
       val x = m.toJson
       println(x)

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/DataSetService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/DataSetService.scala
@@ -48,8 +48,7 @@ class DataSetService(dbActor: ActorRef) extends JobsBaseMicroService with SmrtLi
     toServiceId("smrtlink.dataset"),
     "SMRT Link DataSetService Service",
     "0.1.0",
-    "SMRT Link Analysis DataSet Service",
-    None)
+    "SMRT Link Analysis DataSet Service")
 
   val DATASET_TYPES_PREFIX = "dataset-types"
   val DATASET_PREFIX = "datasets"

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobManagerService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobManagerService.scala
@@ -48,7 +48,7 @@ class JobManagerService(dbActor: ActorRef,
   implicit val routing = RoutingSettings.default
 
   val serviceId = toServiceId("job_manager")
-  val deps = Some(Seq(PacBioComponent(toServiceId("status"), "0.1.0")))
+  val deps = Seq(PacBioComponent(toServiceId("status"), "0.1.0"))
   override val manifest = PacBioComponentManifest(
     serviceId,
     "Service Job Manager",

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/ProjectService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/ProjectService.scala
@@ -44,7 +44,7 @@ class ProjectService(dbActor: ActorRef, userActor: ActorRef, authenticator: Auth
     toServiceId("smrtlink.project"),
     "SMRT Link Project Service",
     "0.1.0",
-    "Project create/read/update", None)
+    "Project create/read/update")
 
   val routes =
     pathPrefix("projects") {

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/RegistryService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/RegistryService.scala
@@ -32,7 +32,7 @@ class RegistryService(registryActor: ActorRef, authenticator: Authenticator)
   val manifest = PacBioComponentManifest(
     COMPONENT_ID,
     "Subsystem Resource Registry Service",
-    COMPONENT_VERSION, "Subsystem Resource Registry Service", None)
+    COMPONENT_VERSION, "Subsystem Resource Registry Service")
 
   val routes =
     //authenticate(authenticator.jwtAuth) { authInfo =>

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/RunService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/RunService.scala
@@ -26,8 +26,7 @@ class RunService(runActor: ActorRef, authenticator: Authenticator)
     toServiceId("runs"),
     "Run Service",
     "0.1.0",
-    "Database-backed CRUD operations for Runs",
-    dependencies = None)
+    "Database-backed CRUD operations for Runs")
 
   val routes =
     //authenticate(authenticator.jwtAuth) { authInfo =>

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/SampleService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/SampleService.scala
@@ -32,7 +32,7 @@ class SampleService(sampleActor: ActorRef, authenticator: Authenticator)
   val manifest = PacBioComponentManifest(
     toServiceId("samples"),
     "Subsystem Sample Service",
-    "0.1.0", "Subsystem Sample Service", None)
+    "0.1.0", "Subsystem Sample Service")
 
   val routes =
   //authenticate(authenticator.jwtAuth) { authInfo =>


### PR DESCRIPTION
CC @mpkocher look good?

In working on #89 I realized `None` is passed many times when `PacBioComponentManifest` is created for services. Only 4 or so uses pass an arg. Making `None` tidies up the code a fair bit and avoids needing to put an (often unnamed) arg of `None`.

#### Old
```scala
case class PacBioComponentManifest(id: String, name: String, version: String, description: String, dependencies: Option[Seq[PacBioComponent]])
```
#### New
```scala
case class PacBioComponentManifest(id: String, name: String, version: String, description: String, dependencies: Option[Seq[PacBioComponent]] = None)
 ```

Which lets you do cleanup such as the following in over 20 spots in our codebase.

```scala
 val manifest = PacBioComponentManifest(toServiceId("smrtlink_resource_resolver"),
     "SMRT Link Resource Resolver", "0.1.0",
-    "Service to resolve job paths from job ids using SMRT Link Resources id.", None)
+    "Service to resolve job paths from job ids using SMRT Link Resources id.")
```