### PR TITLE
Enable running quick workers and standard workers to run jobs by type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@
 
 name := "smrtflow"
 
-version in ThisBuild := "0.1.1-SNAPSHOT"
+version in ThisBuild := "0.1.2-SNAPSHOT"
 
 //FIXME(mpkocher)(2016-4-30) This should be com.pacb, PacBio doesn't own pacbio.com
 organization in ThisBuild := "com.pacbio"

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/CommonMessages.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/CommonMessages.scala
@@ -20,8 +20,6 @@ object CommonMessages {
   case object StandardWorkType extends WorkerType
 
   case class UpdateJobCompletedResult(result: JobResult, workerType: WorkerType)
-  // this idea should be reconsidered. This might not be the best idea
-  case class UpdateQuickJobCompletedResult(result: JobResult, workerType: WorkerType)
 
   // General Successful message. Intended to be used in DAO layer
   case class SuccessMessage(message: String)

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/CommonMessages.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/CommonMessages.scala
@@ -14,7 +14,14 @@ object CommonMessages {
   // Add a new Job
   case class AddNewJob(job: CoreJob)
 
-  case class UpdateJobCompletedResult(result: JobResult)
+  // Not sure if this is the best model for doing this
+  sealed trait WorkerType
+  case object QuickWorkType extends WorkerType
+  case object StandardWorkType extends WorkerType
+
+  case class UpdateJobCompletedResult(result: JobResult, workerType: WorkerType)
+  // this idea should be reconsidered. This might not be the best idea
+  case class UpdateQuickJobCompletedResult(result: JobResult, workerType: WorkerType)
 
   // General Successful message. Intended to be used in DAO layer
   case class SuccessMessage(message: String)

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/actors/EngineManagerActor.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/actors/EngineManagerActor.scala
@@ -58,6 +58,7 @@ class EngineManagerActor(daoActor: ActorRef, engineConfig: EngineConfig, resolve
   // Keep track of workers
   val workers = mutable.Queue[ActorRef]()
 
+  val maxNumQuickWorkers = 10
   // For jobs that are small and can completed in a relatively short amount of time (~seconds) and have minimal resource usage
   val quickWorkers = mutable.Queue[ActorRef]()
 
@@ -69,8 +70,12 @@ class EngineManagerActor(daoActor: ActorRef, engineConfig: EngineConfig, resolve
       workers.enqueue(worker)
       log.debug(s"Creating worker $worker")
     }
-    log.info(s"Created ${workers.size} engine workers")
 
+    (0 until maxNumQuickWorkers).foreach { x =>
+      val worker = context.actorOf(QuickEngineWorkerActor.props(daoActor, jobRunner), s"engine-quick-worker-$x")
+      quickWorkers.enqueue(worker)
+      log.debug(s"Creating Quick worker $worker")
+    }
   }
 
   override def postStop(): Unit = {
@@ -78,35 +83,44 @@ class EngineManagerActor(daoActor: ActorRef, engineConfig: EngineConfig, resolve
     checkForWorkTick.cancel()
   }
 
+  def addJobToWorker(runnableJobWithId: RunnableJobWithId, workerQueue: mutable.Queue[ActorRef]): Unit = {
+
+    if (workerQueue.nonEmpty) {
+      log.debug(s"Checking for work. Number of available Workers ${workerQueue.size}")
+      log.debug(s"Found jobOptions work ${runnableJobWithId.job.jobOptions.toJob.jobTypeId}. Updating state and starting task.")
+
+      // This should be extended to support a list of Status Updates, to avoid another ask call
+      // e.g., UpdateJobStatus(runnableJobWithId.job.uuid, Seq(AnalysisJobStates.SUBMITTED, AnalysisJobStates.RUNNING)
+      val fx = for {
+        f1 <- daoActor ? UpdateJobStatus(runnableJobWithId.job.uuid, AnalysisJobStates.SUBMITTED)
+        f2 <- daoActor ? UpdateJobStatus(runnableJobWithId.job.uuid, AnalysisJobStates.RUNNING)
+      } yield f2
+
+      fx onComplete {
+        case Success(_) =>
+          val worker = workerQueue.dequeue()
+          val outputDir = resolver.resolve(runnableJobWithId)
+          // Update jobOptions output dir
+          daoActor ! UpdateJobOutputDir(runnableJobWithId.job.uuid, outputDir)
+          worker ! RunJob(runnableJobWithId.job, outputDir)
+        case Failure(ex) =>
+          log.error(s"Failed to update job state of ${runnableJobWithId.job} with ${runnableJobWithId.job.uuid.toString}")
+          daoActor ! UpdateJobStatus(runnableJobWithId.job.uuid, AnalysisJobStates.FAILED)
+      }
+    }
+  }
+
   def checkForWork(): Unit = {
     log.debug(s"Checking for work. Number of available Workers ${workers.size}")
 
-    if (workers.nonEmpty) {
+    if (workers.nonEmpty || quickWorkers.nonEmpty) {
       val f = (daoActor ? HasNextRunnableJobWithId).mapTo[Either[NoAvailableWorkError, RunnableJobWithId]]
 
       f onSuccess {
         case Right(runnableJob) =>
-          if (workers.nonEmpty) {
-            log.debug(s"Checking for work. Number of available Workers ${workers.size}")
-            log.debug(s"Found jobOptions work ${runnableJob.job.jobOptions.toJob.jobTypeId}. Updating state and starting task.")
-
-            val fx = for {
-              f1 <- daoActor ? UpdateJobStatus(runnableJob.job.uuid, AnalysisJobStates.SUBMITTED)
-              f2 <- daoActor ? UpdateJobStatus(runnableJob.job.uuid, AnalysisJobStates.RUNNING)
-            } yield f2
-
-            fx onComplete {
-              case Success(_) =>
-                val worker = workers.dequeue()
-                val outputDir = resolver.resolve(runnableJob)
-                // Update jobOptions output dir
-                daoActor ! UpdateJobOutputDir(runnableJob.job.uuid, outputDir)
-                worker ! RunJob(runnableJob.job, outputDir)
-              case Failure(ex) =>
-                log.error(s"Failed to update job state of ${runnableJob.job} with ${runnableJob.job.uuid.toString}")
-                daoActor ! UpdateJobStatus(runnableJob.job.uuid, AnalysisJobStates.FAILED)
-            }
-          }
+          val jobType = runnableJob.job.jobOptions.toJob.jobTypeId
+          if ((QUICK_TASK_IDS contains jobType) && quickWorkers.nonEmpty) addJobToWorker(runnableJob, quickWorkers)
+          else addJobToWorker(runnableJob, workers)
         case Left(e) => log.debug(s"No work found. ${e.message}")
       }
 
@@ -146,15 +160,21 @@ class EngineManagerActor(daoActor: ActorRef, engineConfig: EngineConfig, resolve
         case Failure(ex) => log.error(s"Failed check for runnable jobs ${ex.getMessage}")
       }
 
-    case UpdateJobCompletedResult(result) =>
+    case UpdateJobCompletedResult(result, workerType) =>
       // This should have a success/failure
       result.state match {
         case x: Completed =>
           daoActor ! UpdateJobStatus(result.uuid, result.state)
-          workers.enqueue(sender)
+          workerType match {
+            case QuickWorkType => quickWorkers.enqueue(sender)
+            case StandardWorkType => workers.enqueue(sender)
+          }
           self ! CheckForRunnableJob
         case x => log.error(s"state must be a completed state. Got $result")
-          workers.enqueue(sender)
+          workerType match {
+            case QuickWorkType => quickWorkers.enqueue(sender)
+            case StandardWorkType => workers.enqueue(sender)
+          }
           self ! CheckForRunnableJob
       }
 

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/actors/EngineWorkerActor.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/actors/EngineWorkerActor.scala
@@ -26,6 +26,8 @@ class EngineWorkerActor(daoActor: ActorRef, jobRunner: JobRunner) extends Actor
 with ActorLogging
 with timeUtils {
 
+  val WORK_TYPE = StandardWorkType
+
   override def preStart(): Unit = {
     log.debug(s"Starting engine-worker $self")
   }
@@ -53,11 +55,11 @@ with timeUtils {
 
       val message = result match {
         case Right(x) =>
-          UpdateJobCompletedResult(x)
+          UpdateJobCompletedResult(x, WORK_TYPE)
         case Left(ex) =>
           val emsg = s"Failed job type ${jobTypeId.id} in ${outputDir.toAbsolutePath} Job: $job  ${ex.message}"
           log.error(emsg)
-          UpdateJobCompletedResult(ex)
+          UpdateJobCompletedResult(ex, WORK_TYPE)
       }
 
       stderrFw.close()
@@ -67,4 +69,12 @@ with timeUtils {
 
     case x => log.debug(s"Unhandled Message to Engine Worker $x")
   }
+}
+
+object QuickEngineWorkerActor {
+  def props(daoActor: ActorRef, jobRunner: JobRunner): Props = Props(new QuickEngineWorkerActor(daoActor, jobRunner))
+}
+
+class QuickEngineWorkerActor(daoActor: ActorRef, jobRunner: JobRunner) extends EngineWorkerActor(daoActor, jobRunner){
+  override val WORK_TYPE = QuickWorkType
 }


### PR DESCRIPTION
- "quick" jobs will run in quick workers if avail, or default to the standard workers (if avail)
- Not thrilled but trying to keep the changes to a minimum (want this up on SL beta)
- I have a better longer term solution