### PR TITLE
Load version from existing version.properties

### DIFF
--- a/smrt-server-base/src/main/scala/com/pacbio/common/actors/StatusServiceActor.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/actors/StatusServiceActor.scala
@@ -1,11 +1,13 @@
 package com.pacbio.common.actors
 
-import java.util.UUID
+import java.util.{Properties, UUID}
 
-import akka.actor.{Props, ActorRef}
+import akka.actor.{ActorRef, Props}
 import com.pacbio.common.dependency.Singleton
 import com.pacbio.common.time.{Clock, ClockProvider}
 import org.joda.time.{Duration => JodaDuration, Instant => JodaInstant}
+import scala.collection.JavaConverters._
+
 
 /**
  * Companion object for the StatusServiceActor class, defining the set of messages it can handle.
@@ -58,8 +60,23 @@ sealed trait BaseStatusServiceActorProvider {
 
   val uuid: Singleton[UUID] = Singleton(UUID.randomUUID())
 
-  val buildVersion: Singleton[String] = Singleton(() =>
-    Option(buildPackage()).flatMap { p => Option(p.getImplementationVersion) }.getOrElse("unknown version")
+  val buildVersion: Singleton[String] = Singleton(() => {
+      val files = getClass().getClassLoader().getResources("version.properties")
+      if (files.hasMoreElements) {
+        val in = files.nextElement().openStream()
+        try {
+          val prop = new Properties
+          prop.load(in)
+          prop.getProperty("version")
+        }
+        finally {
+          in.close()
+        }
+      }
+      else {
+        "unknown version"
+      }
+    }
   )
 }
 


### PR DESCRIPTION
Fixes #84 

Loading property files in scala seems to rely on the same old (slightly) cumbersome Java `Properties` and `load` method. I updated our `buildVersion` method to do that.

```bash
# remake the needed JAR
sbt clean smrt-server-analysis/assembly smrt-server-analysis/run

# check the version via URL
curl http://localhost:8070/status

{
  "uuid": "f18647c4-591a-462c-8867-96fc28c26505",
  "version": "af4a30e670a76f3a38e2fdc420455c830e0dc479",
  "id": "pacbio.smrtservices.smrtlink_analysis",
  "uptime": 4388,
  "message": "Services have been up for 4.388 seconds.",
  "user": "jfalkner"
}
```

I couldn't find a convenient Scala way to walk the ClassLoader tree, look for `properties` files with a given name and give the first one back as a map. I may cook this up for fun.