### PR TITLE
Short version format. e.g. "0.1.2-f1cdc23"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val common = (
     settings(
     makeVersionProperties := {
       val propFile = (resourceManaged in Compile).value / "version.properties"
-      val content = "version=%s" format (gitHeadCommitSha.value)
+      val content = "version=%s\nsha1=%s" format (version.value, gitHeadCommitSha.value)
       IO.write(propFile, content)
       Seq(propFile)
     },

--- a/smrt-server-base/src/main/scala/com/pacbio/common/actors/StatusServiceActor.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/actors/StatusServiceActor.scala
@@ -67,7 +67,7 @@ sealed trait BaseStatusServiceActorProvider {
         try {
           val prop = new Properties
           prop.load(in)
-          prop.getProperty("version")
+          prop.getProperty("version").replace("SNAPSHOT", "") + prop.getProperty("sha1").substring(0, 7)
         }
         finally {
           in.close()


### PR DESCRIPTION
CC @mpkocher 

Fixes #84 and followup to #107 

Conversion to use a common name + abbreviated hash in the version string. Now version strings appear similar to `0.1.2-f1cdc23` where the values are VERSION + SHA1, when VERSION has "SNAPSHOT" trimmed and the SHA1 is truncated to 7 chars.

Full version and SHA are available in the `verrsion.properties` file. 

Example showing how to see this version string.

```
# remake the needed JAR
sbt clean smrt-server-analysis/assembly smrt-server-analysis/run

# check the version via URL
curl http://localhost:8070/status

{
  "uuid": "c7faa168-6965-4932-86e8-eba51f1f2b12",
  "version": "0.1.2-f1cdc23",
  "id": "pacbio.smrtservices.smrtlink_analysis",
  "uptime": 2593,
  "message": "Services have been up for 2.593 seconds.",
  "user": "jfalkner"
}
```