### PR TITLE
Logger default level INFO and reduce Slick logging verbosity

### DIFF
--- a/smrt-server-logging/README.md
+++ b/smrt-server-logging/README.md
@@ -7,7 +7,7 @@ Simple logging for two common use cases in the PacBio tools. See [smrtflow#42](h
 ```bash
 $ ./smrt-server-tools/target/pack/bin/get-smrt-server-status -h
 ...
-  --debug
+  --log2stdout
         If true, log output will be displayed to the console. Default is false.
   --loglevel <value>
         Level for logging: "ERROR", "WARN", "DEBUG", or "INFO". Default is "ERROR"
@@ -48,6 +48,19 @@ case class GetStatusConfig(host: String = "http://localhost",
   }
 ```
 
+Alternatively, use the `LoggerOptions.parse` and related methods to directly parse an arg array.
+
+```scala
+object MyCode extends App {
+  // whatever pre-logging config logic ...
+  
+  // parse the args for logging related options
+  LoggerOptions.parseAddDebug(args)
+  
+  // whatever post-logging conig logic
+}
+```
+
 ## Command-Line Example
 
 There are a few practical use cases that are supported. By default, logging information is not displayed.
@@ -70,17 +83,17 @@ support this versus requiring a custom log config file or property file.
 
 ### Dev Logging
 
-When working on the code you probably always want to see errors. If that is true, run with `--debug` and
+When working on the code you probably always want to see errors. If that is true, run with `--log2stdout` and
 `--loglevel ERROR`
 
 ```bash
-./smrt-server-tools/target/pack/bin/some_service --debug --loglevel ERROR
+./smrt-server-tools/target/pack/bin/some_service --log2stdout --loglevel ERROR
 ```
 
 Here is the more verbose, show me all log messages example.
 
 ```bash
-./smrt-server-tools/target/pack/bin/some_service --debug --loglevel DEBUG
+./smrt-server-tools/target/pack/bin/some_service --log2stdout --loglevel DEBUG
 ```
 
 ### Using a logback.xml config

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerConfig.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerConfig.scala
@@ -72,6 +72,7 @@ trait LoggerConfig {
    * @return How many params were consumed
    */
   def setLogback(path: String) {
+    this.logbackFile = path
     val lc = LoggerFactory.getILoggerFactory().asInstanceOf[LoggerContext]
     val configurator = new JoranConfigurator()
     configurator.setContext(lc)
@@ -88,9 +89,10 @@ trait LoggerConfig {
    * @return How many params were consumed
    */
   def setLevel(level: String) {
+    this.logLevel = level
     val lc = LoggerFactory.getILoggerFactory().asInstanceOf[LoggerContext]
     val l = Level.toLevel(level)
-    for (logger <- lc.getLoggerList) { logger.setLevel(l) }
+    for (logger <- lc.getLoggerList) logger.setLevel(l)
   }
 
   /**
@@ -100,6 +102,7 @@ trait LoggerConfig {
    * @return How many params were consumed
    */
   def setFile(file: String) {
+    this.logFile = file
     val lc = LoggerFactory.getILoggerFactory().asInstanceOf[LoggerContext]
 
     // configure the rolling file appender
@@ -142,10 +145,11 @@ trait LoggerConfig {
    * @return How many params were consumed
    */
   def setDebug(debug: Boolean) {
+    this.debug = debug
     if (!debug) return
     val lc = LoggerFactory.getILoggerFactory().asInstanceOf[LoggerContext]
     // build up a SLFJ4 console logger
-    val appender = new ConsoleAppender[ILoggingEvent]();
+    val appender = new ConsoleAppender[ILoggingEvent]()
     appender.setContext(lc)
     appender.setName("STDOUT")
     val patternEncoder = new PatternLayoutEncoder()

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerConfig.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerConfig.scala
@@ -18,7 +18,7 @@ import scala.collection.JavaConversions._
 trait LoggerConfig {
 
   // params for logger configuration
-  var logLevel = "ERROR"
+  var logLevel = "INFO"
   var logFile = "default_smrt.log"
   var logbackFile: String = null
   var debug = false
@@ -43,17 +43,23 @@ trait LoggerConfig {
       debug: Boolean,
       logLevel: String): LoggerConfig = {
 
-    // ignore the default config
-    LoggerOptions.configured = true
     // logback.xml trumps all other config
     if (logbackFile != this.logbackFile)
       setLogback(logbackFile)
     else {
       // order matters here so that debug can trump file and level is correctly set
-      if (logFile != this.logFile) setFile(logFile)
-      if (debug != this.debug) setDebug(debug)
+      if (logFile != this.logFile) {
+        setFile(logFile)
+        setLevel(this.logLevel)
+      }
+      if (debug != this.debug) {
+        setDebug(debug)
+        setLevel(this.logLevel)
+      }
       if (logLevel != this.logLevel) setLevel(logLevel)
     }
+    // ignore the default configurator
+    LoggerOptions.configured = true
     return this
   }
 
@@ -156,6 +162,7 @@ trait LoggerConfig {
       // remove any old appenders
       logger.detachAndStopAllAppenders()
     }
-    lc.getLogger(Logger.ROOT_LOGGER_NAME).addAppender(appender)
+    val logger = lc.getLogger(Logger.ROOT_LOGGER_NAME)
+    logger.addAppender(appender)
   }
 }

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerConfig.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerConfig.scala
@@ -162,7 +162,6 @@ trait LoggerConfig {
       // remove any old appenders
       logger.detachAndStopAllAppenders()
     }
-    val logger = lc.getLogger(Logger.ROOT_LOGGER_NAME)
-    logger.addAppender(appender)
+    lc.getLogger(Logger.ROOT_LOGGER_NAME).addAppender(appender)
   }
 }

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
@@ -21,7 +21,7 @@ object LoggerOptions {
    */
   def add(parser: OptionParser[LoggerConfig]): Unit = {
 
-    parser.opt[Unit]("debug") action { (x, c) =>
+    parser.opt[Unit]("log2stdout") action { (x, c) =>
       c.configure(c.logbackFile, c.logFile, true, c.logLevel)
     } text "If true, log output will be displayed to the console. Default is false."
 
@@ -61,8 +61,8 @@ object LoggerOptions {
   }
 
   def parseAddDebug(args: Seq[String]): Unit = {
-    val requireOne = Set("--logfile", "--debug", "-h")
-    val v = if (args.filter(requireOne).isEmpty) args :+ "--debug" else args
+    val requireOne = Set("--logfile", "--log2stdout", "-h")
+    val v = if (args.filter(requireOne).isEmpty) args :+ "--log2stdout" else args
     parse(v)
   }
 }


### PR DESCRIPTION
CC @skinner @mpkocher 

Fixes #103

This PR updates the default logging behavior to match the [clarified expectations](https://github.com/PacificBiosciences/smrtflow/issues/103#issuecomment-222753670) here. The change also ends up reducing a chunk of the verbose Slick logging #103 since it hides DEBUG level messages. I also improved the code to persist logging config state since sometimes the `Configurator` timing appears to sometimes change. e.g. debugger vs command-line

[README.md docs](https://github.com/PacificBiosciences/smrtflow/blob/logger_debug_default/smrt-server-logging/README.md) are updated too.

Can test by running the analysis server.

```bash
# rebuild the JAR needed for command-line use
sbt clean compile smrt-server-analysis/assembly

# run the analysis server from command line
sbt smrt-server-analysis/run

...
[info] 2016-06-01  INFO [smrtlink-analysis-server-akka.actor.default-dispatcher-2] c.p.s.s.a.SecondaryApi$$anon$1 - Loaded pb-engine.max-workers -> 35
[info] Warning. Assuming relative path /Users/jfalkner/tokeep/git/PacificBiosciences/smrtflow/smrt-server-analysis/jobs-root
[info] 2016-06-01  INFO [smrtlink-analysis-server-akka.actor.default-dispatcher-2] c.p.s.s.a.SecondaryApi$$anon$1 - Loaded pb-engine.pb-tools-env -> 
[info] 2016-06-01 16:08:07.024UTC INFO [smrtlink-analysis-server-akka.actor.default-dispatcher-3] c.p.s.a.e.a.EngineDaoActor - Starting DAO actor
[info] 2016-06-01 16:08:07.028UTC INFO [smrtlink-analysis-server-akka.actor.default-dispatcher-3] c.p.s.a.e.a.EngineManagerActor - Starting manager actor Actor[akka://smrtlink-analysis-server/user/engine-manager#987122468] with EngineConfig(35,,/Users/jfalkner/tokeep/git/PacificBiosciences/smrtflow/smrt-server-analys
```

And you can toggle verbosity as follows.

```bash
# only show errors
sbt "smrt-server-analysis/run --loglevel ERROR"
...
[error] [WARNING] Unable to load CMD template from pb-engine.pb-cmd-template Error No configuration setting found for key 'pb-engine.pb-cmd-template'
```

Similarly in files

```bash
sbt "smrt-server-analysis/run --logfile my_file.log --loglevel ERROR"
```