### PR TITLE
Scalastyle Checker: Part 2

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -53,6 +53,7 @@
     <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
    </parameters>
   </check>
+  -->
 <!-- Ignored - not limit to number of params in style specs, albeit less is normally preferred -->
 <!--
   <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
@@ -69,11 +70,13 @@
    </parameters>
   </check>
 -->
-<!-- Ignored -- no strict rules regarding spacing and brackets -->
+<!-- Ignored - no strict rules regarding spacing and brackets -->
 <!--
   <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
 -->
+ <!-- see http://docs.scala-lang.org/style/declarations#methods "You should specify a return type for all public members" -->
+ <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
 <!--
   <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -45,7 +45,11 @@
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
   </parameters>
  </check>
- <!-- see http://docs.scala-lang.org/style/naming-conventions -->
+ <!-- see http://docs.scala-lang.org/style/naming-conventions
+
+ Also "Underscores in names (_) are not actually forbidden by the compiler, but are strongly
+       discouraged as they have special meaning within the Scala syntax."
+ -->
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[^[a-z\*][A-Za-z0-9]*$]]></parameter>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -10,20 +10,30 @@
    <parameter name="methodParamIndentSize">4</parameter>
   </parameters>
  </check>
+ <!-- Ignore - no explicit rule in style guides; however, handy to avoid whitespace diffs -->
+ <!--
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+ -->
+ <!-- Ignored - there is line limit in files in the style guides -->
  <!--
  <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxFileLength"><![CDATA[800]]></parameter>
   </parameters>
  </check>
+ -->
+<!-- Ignored - Scala's style always shows spaces but doesn't required it -->
+ <!--
  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+-->
+<!--
  <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
   </parameters>
  </check>
+ 
  <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -33,83 +33,84 @@
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
   </parameters>
  </check>
-<!--
+ <!-- see http://docs.scala-lang.org/style/naming-conventions -->
  <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
-  <parameters>
-   <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
-  <parameters>
-   <parameter name="maxParameters"><![CDATA[8]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
-  <parameters>
-   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[println]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
-  <parameters>
-   <parameter name="maxTypes"><![CDATA[30]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
-  <parameters>
-   <parameter name="maximum"><![CDATA[10]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
-  <parameters>
-   <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
-   <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxLength"><![CDATA[50]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
-  <parameters>
-   <parameter name="maxMethods"><![CDATA[30]]></parameter>
-  </parameters>
- </check>
- <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
- -->
+ <!--
+  <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+   <parameters>
+    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+   <parameters>
+    <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+   <parameters>
+    <parameter name="maxParameters"><![CDATA[8]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+   <parameters>
+    <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+   <parameters>
+    <parameter name="regex"><![CDATA[println]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+   <parameters>
+    <parameter name="maxTypes"><![CDATA[30]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+   <parameters>
+    <parameter name="maximum"><![CDATA[10]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+   <parameters>
+    <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+    <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+   <parameters>
+    <parameter name="maxLength"><![CDATA[50]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+   <parameters>
+    <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+   <parameters>
+    <parameter name="maxMethods"><![CDATA[30]]></parameter>
+   </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+  -->
  <!-- 100 char line length and 2 space indent from Effective Scala - http://twitter.github.io/effectivescala/#Formatting -->
 <!--
  <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -45,6 +45,12 @@
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
   </parameters>
  </check>
+ <!-- see http://docs.scala-lang.org/style/naming-conventions -->
+ <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z\*][A-Za-z0-9]*$]]></parameter>
+  </parameters>
+ </check>
  <!-- Ignored - good practice but not required in style docs -->
  <!--
   <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
@@ -75,8 +81,10 @@
   <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
 -->
- <!-- see http://docs.scala-lang.org/style/declarations#methods "You should specify a return type for all public members" -->
+ <!-- TODO: see http://docs.scala-lang.org/style/declarations#methods "You should specify a return type for all public members" -->
+ <!--
  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+ -->
 <!--
   <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
@@ -110,11 +118,6 @@
   <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
    <parameters>
     <parameter name="maxLength"><![CDATA[50]]></parameter>
-   </parameters>
-  </check>
-  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
-   <parameters>
-    <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
    </parameters>
   </check>
   <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -27,13 +27,13 @@
  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
 -->
-<!--
+ <!-- see http://docs.scala-lang.org/style/naming-conventions -->
  <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
   </parameters>
  </check>
- 
+<!--
  <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -39,12 +39,13 @@
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
   </parameters>
  </check>
+ <!-- see http://docs.scala-lang.org/style/naming-conventions -->
+ <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+  </parameters>
+ </check>
  <!--
-  <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
-   <parameters>
-    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
-   </parameters>
-  </check>
   <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
    <parameters>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,145 +1,149 @@
 <scalastyle>
- <!-- See https://github.com/PacificBiosciences/smrtflow/pull/95 -->
- <name>PacBio Scala style checker</name>
- <!-- "2-space convention" - see http://docs.scala-lang.org/style/indentation -->
- <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
- <!-- "Declarations" - http://docs.scala-lang.org/style/declarations -->
- <check enabled="true" class="org.scalastyle.file.IndentationChecker" level="warning">
-  <parameters>
-   <parameter name="tabSize">2</parameter>
-   <parameter name="methodParamIndentSize">4</parameter>
-  </parameters>
- </check>
- <!-- Ignore - no explicit rule in style guides; however, handy to avoid whitespace diffs -->
- <!--
- <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
- -->
- <!-- Ignored - there is line limit in files in the style guides -->
- <!--
- <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
-  </parameters>
- </check>
- -->
-<!-- Ignored - Scala's style always shows spaces but doesn't required it -->
- <!--
- <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
--->
- <!-- see http://docs.scala-lang.org/style/naming-conventions -->
- <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
-  </parameters>
- </check>
- <!-- see http://docs.scala-lang.org/style/naming-conventions -->
- <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
-  </parameters>
- </check>
- <!-- see http://docs.scala-lang.org/style/naming-conventions -->
- <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
-  </parameters>
- </check>
- <!-- see http://docs.scala-lang.org/style/naming-conventions
+    <!-- See https://github.com/PacificBiosciences/smrtflow/pull/95 -->
+    <name>PacBio Scala style checker</name>
 
- Also "Underscores in names (_) are not actually forbidden by the compiler, but are strongly
-       discouraged as they have special meaning within the Scala syntax."
- -->
- <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[^[a-z\*+><?][A-Za-z0-9?=]*$]]></parameter>
-  </parameters>
- </check>
- <!-- Ignored - good practice but not required in style docs -->
- <!--
-  <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
-   <parameters>
-    <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
-   </parameters>
-  </check>
-  -->
-<!-- Ignored - not limit to number of params in style specs, albeit less is normally preferred -->
-<!--
-  <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
-   <parameters>
-    <parameter name="maxParameters"><![CDATA[8]]></parameter>
-   </parameters>
-  </check>
--->
-<!-- Ignored - magic numbers usually aren't good but no style restriction on them -->
-<!--
-  <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
-   <parameters>
-    <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
-   </parameters>
-  </check>
--->
-<!-- Ignored - no strict rules regarding spacing and brackets -->
-<!--
-  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
--->
- <!-- TODO: see http://docs.scala-lang.org/style/declarations#methods "You should specify a return type for all public members" -->
- <!--
- <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
- -->
-<!--
-  <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
-   <parameters>
-    <parameter name="regex"><![CDATA[println]]></parameter>
-   </parameters>
-  </check>
-  <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
-   <parameters>
-    <parameter name="maxTypes"><![CDATA[30]]></parameter>
-   </parameters>
-  </check>
-  <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
-   <parameters>
-    <parameter name="maximum"><![CDATA[10]]></parameter>
-   </parameters>
-  </check>
-  <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
-   <parameters>
-    <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
-    <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
-   </parameters>
-  </check>
-  <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
-   <parameters>
-    <parameter name="maxLength"><![CDATA[50]]></parameter>
-   </parameters>
-  </check>
-  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
-   <parameters>
-    <parameter name="maxMethods"><![CDATA[30]]></parameter>
-   </parameters>
-  </check>
-  <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
-  -->
- <!-- 100 char line length and 2 space indent from Effective Scala - http://twitter.github.io/effectivescala/#Formatting -->
-<!--
- <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxLineLength"><![CDATA[100]]></parameter>
-   <parameter name="tabSize"><![CDATA[2]]></parameter>
-  </parameters>
- </check>
--->
+    <!-- "2-space convention" - see http://docs.scala-lang.org/style/indentation -->
+    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <!-- "Declarations" - http://docs.scala-lang.org/style/declarations -->
+    <check enabled="true" class="org.scalastyle.file.IndentationChecker" level="warning">
+        <parameters>
+            <parameter name="tabSize">2</parameter>
+            <parameter name="methodParamIndentSize">4</parameter>
+        </parameters>
+    </check>
+    <!-- see http://docs.scala-lang.org/style/naming-conventions -->
+    <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <!-- see http://docs.scala-lang.org/style/naming-conventions -->
+    <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <!-- see http://docs.scala-lang.org/style/naming-conventions -->
+    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker"
+           enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+        </parameters>
+    </check>
+    <!-- see http://docs.scala-lang.org/style/naming-conventions
+
+    Also "Underscores in names (_) are not actually forbidden by the compiler, but are strongly
+          discouraged as they have special meaning within the Scala syntax."
+    -->
+    <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z\*+><?][A-Za-z0-9?=]*$]]></parameter>
+        </parameters>
+    </check>
+
+    <!-- TODO: see http://docs.scala-lang.org/style/declarations#methods "You should specify a return type for all public members" -->
+    <!--
+    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+    -->
+
+    <!-- Ignore - no explicit rule in style guides; however, handy to avoid whitespace diffs -->
+    <!--
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+    -->
+    <!-- Ignored - there is line limit in files in the style guides -->
+    <!--
+    <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+     <parameters>
+      <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+     </parameters>
+    </check>
+    -->
+    <!-- Ignored - Scala's style always shows spaces but doesn't required it -->
+    <!--
+    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+   -->
+    <!-- Ignored - good practice but not required in style docs -->
+    <!--
+     <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+     <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+      <parameters>
+       <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+      </parameters>
+     </check>
+     -->
+    <!-- Ignored - not limit to number of params in style specs, albeit less is normally preferred -->
+    <!--
+      <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+       <parameters>
+        <parameter name="maxParameters"><![CDATA[8]]></parameter>
+       </parameters>
+      </check>
+    -->
+    <!-- Ignored - magic numbers usually aren't good but no style restriction on them -->
+    <!--
+      <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+       <parameters>
+        <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+       </parameters>
+      </check>
+    -->
+    <!-- Ignored - no strict rules regarding spacing and brackets -->
+    <!--
+      <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+    -->
+    <!--
+      <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+       <parameters>
+        <parameter name="regex"><![CDATA[println]]></parameter>
+       </parameters>
+      </check>
+      <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+       <parameters>
+        <parameter name="maxTypes"><![CDATA[30]]></parameter>
+       </parameters>
+      </check>
+      <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+       <parameters>
+        <parameter name="maximum"><![CDATA[10]]></parameter>
+       </parameters>
+      </check>
+      <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+       <parameters>
+        <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+        <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+       </parameters>
+      </check>
+      <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+       <parameters>
+        <parameter name="maxLength"><![CDATA[50]]></parameter>
+       </parameters>
+      </check>
+      <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+       <parameters>
+        <parameter name="maxMethods"><![CDATA[30]]></parameter>
+       </parameters>
+      </check>
+      <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+      <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+      -->
+    <!-- 100 char line length and 2 space indent from Effective Scala - http://twitter.github.io/effectivescala/#Formatting -->
+    <!--
+     <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+      <parameters>
+       <parameter name="maxLineLength"><![CDATA[100]]></parameter>
+       <parameter name="tabSize"><![CDATA[2]]></parameter>
+      </parameters>
+     </check>
+    -->
 
 </scalastyle>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -52,7 +52,7 @@
  -->
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
   <parameters>
-   <parameter name="regex"><![CDATA[^[a-z\*][A-Za-z0-9]*$]]></parameter>
+   <parameter name="regex"><![CDATA[^[a-z\*+><?][A-Za-z0-9?=]*$]]></parameter>
   </parameters>
  </check>
  <!-- Ignored - good practice but not required in style docs -->

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -45,6 +45,7 @@
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
   </parameters>
  </check>
+ <!-- Ignored - good practice but not required in style docs -->
  <!--
   <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
@@ -52,18 +53,28 @@
     <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
    </parameters>
   </check>
+<!-- Ignored - not limit to number of params in style specs, albeit less is normally preferred -->
+<!--
   <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
    <parameters>
     <parameter name="maxParameters"><![CDATA[8]]></parameter>
    </parameters>
   </check>
+-->
+<!-- Ignored - magic numbers usually aren't good but no style restriction on them -->
+<!--
   <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
    <parameters>
     <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
    </parameters>
   </check>
+-->
+<!-- Ignored -- no strict rules regarding spacing and brackets -->
+<!--
   <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+-->
+<!--
   <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
@@ -108,7 +119,6 @@
     <parameter name="maxMethods"><![CDATA[30]]></parameter>
    </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
   <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
   -->

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/converters/FastaConverter.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/converters/FastaConverter.scala
@@ -118,7 +118,7 @@ object FastaConverter extends LazyLogging{
   case class PacBioFastaRecord(header: String, metadata: Option[String], bases: Seq[Char], recordIndex: Int)
 
 
-  def _validateCharNotInHeader(char: Char): PacBioFastaRecord => Either[InValidFastaFileError, PacBioFastaRecord] = {
+  def validateCharNotInHeader(char: Char): PacBioFastaRecord => Either[InValidFastaFileError, PacBioFastaRecord] = {
 
     def validateC(fastaRecord: PacBioFastaRecord): Either[InValidFastaFileError, PacBioFastaRecord] = {
       if (fastaRecord.header contains char) {
@@ -130,9 +130,9 @@ object FastaConverter extends LazyLogging{
     validateC
   }
 
-  val validateNoDoubleQuote = _validateCharNotInHeader('\"')
-  val validateNoColon = _validateCharNotInHeader(':')
-  val validateNoTab = _validateCharNotInHeader('\t')
+  val validateNoDoubleQuote = validateCharNotInHeader('\"')
+  val validateNoColon = validateCharNotInHeader(':')
+  val validateNoTab = validateCharNotInHeader('\t')
 
   /**
    * Validate a PacBio Fasta Record
@@ -146,6 +146,7 @@ object FastaConverter extends LazyLogging{
    * Using Either to propagate up Error messages
    *
    * Bases must only contain IUPAC (or lowercase versions)
+ *
    * @param fastaRecord
    * @return
    */
@@ -166,6 +167,7 @@ object FastaConverter extends LazyLogging{
 
   /**
    * Validate that Fasta file is compliant with PacBio Spec
+ *
    * @param path
    * @return
    */
@@ -219,6 +221,7 @@ object FastaConverter extends LazyLogging{
   /**
    * This is the new model for writing a ReferenceSet using jaxb
    * This should eventually replace the manual XML ReferenceSet creation
+ *
    * @param contigs
    * @return
    */

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/reports/Reports.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/reports/Reports.scala
@@ -88,10 +88,10 @@ object MockReportUtils extends ReportJsonProtocol {
     ReportTable("report_table", "report title", JsArray(cs.toVector))
   }
 
-  /*
-  Generate a pbreport-eseque task/jobOptions report of the execution
+  /**
+   * Generate a pbreport-eseque task/jobOptions report of the execution
    */
-  def toMockTaskReport(reportId: String) = {
+  def toMockTaskReport(reportId: String): Report = {
     def toI(x: String) = s"$reportId.$x"
     def toRa(i: String, n: String, v: Int) = ReportLongAttribute(i, n, v)
     val xs = Seq(("host", "Host ", 1234),

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/SubSystemResourceService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/SubSystemResourceService.scala
@@ -27,14 +27,14 @@ class SubSystemResourceService extends PacBioService {
     mutable.Map(exampleResource.uuid -> exampleResource)
   }
 
-  def _findResourceOrError(uuid: java.util.UUID): Try[SubsystemResource] = Try {
+  private def findResourceOrError(uuid: java.util.UUID): Try[SubsystemResource] = Try {
     if (_subsystemResources.contains(uuid))
       _subsystemResources(uuid)
     else
       throw new NoSuchElementException(s"Unable to find resource $uuid")
   }
 
-  def _deleteResourceOrError(uuid: java.util.UUID): Try[String] = Try {
+  private def deleteResourceOrError(uuid: java.util.UUID): Try[String] = Try {
     if (_subsystemResources.contains(uuid)) {
       _subsystemResources -= uuid
       s"Successfully deleted resource $uuid"
@@ -66,14 +66,14 @@ class SubSystemResourceService extends PacBioService {
         get {
           complete {
             ok {
-              _findResourceOrError(_uuid)
+              findResourceOrError(_uuid)
             }
           }
         } ~
         delete {
           complete {
             ok {
-              _deleteResourceOrError(_uuid)
+              deleteResourceOrError(_uuid)
             }
           }
         }

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/package.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/package.scala
@@ -213,7 +213,7 @@ package object services {
 
   trait ServiceIdUtils {
 
-    def _toServiceId(n: PacBioNamespaces.PacBioNamespace, s: String) = "pacbio." + n.toString.toLowerCase + "." + s.toLowerCase
+    private def toServiceId(n: PacBioNamespaces.PacBioNamespace, s: String) = "pacbio." + n.toString.toLowerCase + "." + s.toLowerCase
 
     /**
      * Util for creating Pacbio Tool ID type (e.g., pacbio.services.my_id, pacbio.services.secondary.internal_dataset)
@@ -221,13 +221,14 @@ package object services {
      * Subsystems resources have 3 types of components, Tools (e.g., blasr),
      * Services, SMRTApps (angular). SMRT Apps can depend on Services and SMRT Apps, Services can depend on other
      * Services and Tools. Tools can only depend on other Tools.
+     *
      * @param s base Id name
      * @return
      */
-    def toToolId(s: String): String = _toServiceId(PacBioNamespaces.SMRTTools, s)
+    def toToolId(s: String): String = toServiceId(PacBioNamespaces.SMRTTools, s)
 
-    def toAppId(s: String): String = _toServiceId(PacBioNamespaces.SMRTApps, s)
+    def toAppId(s: String): String = toServiceId(PacBioNamespaces.SMRTApps, s)
 
-    def toServiceId(s: String): String = _toServiceId(PacBioNamespaces.SMRTServices, s)
+    def toServiceId(s: String): String = toServiceId(PacBioNamespaces.SMRTServices, s)
   }
 }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -692,13 +692,13 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
       q.result.headOption.map(_.map(x => toSds(x._1, x._2)))
     }
 
-  def _subreadToDetails(ds: Future[Option[SubreadServiceDataSet]]): Future[Option[String]] =
+  private def subreadToDetails(ds: Future[Option[SubreadServiceDataSet]]): Future[Option[String]] =
     ds.map(_.map(x => DataSetJsonUtils.subreadSetToJson(DataSetLoader.loadSubreadSet(Paths.get(x.path)))))
 
 
-  def getSubreadDataSetDetailsById(id: Int): Future[Option[String]] = _subreadToDetails(getSubreadDataSetById(id))
+  def getSubreadDataSetDetailsById(id: Int): Future[Option[String]] = subreadToDetails(getSubreadDataSetById(id))
 
-  def getSubreadDataSetDetailsByUUID(uuid: UUID): Future[Option[String]] = _subreadToDetails(getSubreadDataSetByUUID(uuid))
+  def getSubreadDataSetDetailsByUUID(uuid: UUID): Future[Option[String]] = subreadToDetails(getSubreadDataSetByUUID(uuid))
 
   def getSubreadDataSetByUUID(id: UUID): Future[Option[SubreadServiceDataSet]] =
     dal.db.run {
@@ -729,13 +729,13 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
       q.result.headOption.map(_.map(x => toR(x._1, x._2)))
     }
 
-  def _referenceToDetails(ds: Future[Option[ReferenceServiceDataSet]]): Future[Option[String]] =
+  private def referenceToDetails(ds: Future[Option[ReferenceServiceDataSet]]): Future[Option[String]] =
     ds.map(_.map(x => DataSetJsonUtils.referenceSetToJson(DataSetLoader.loadReferenceSet(Paths.get(x.path)))))
 
-  def getReferenceDataSetDetailsById(id: Int): Future[Option[String]] = _referenceToDetails(getReferenceDataSetById(id))
+  def getReferenceDataSetDetailsById(id: Int): Future[Option[String]] = referenceToDetails(getReferenceDataSetById(id))
 
   def getReferenceDataSetDetailsByUUID(uuid: UUID): Future[Option[String]] =
-    _referenceToDetails(getReferenceDataSetByUUID(uuid))
+    referenceToDetails(getReferenceDataSetByUUID(uuid))
 
   def getReferenceDataSetByUUID(id: UUID): Future[Option[ReferenceServiceDataSet]] =
     dal.db.run {
@@ -759,12 +759,12 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
       q.result.headOption.map(_.map(x => toHds(x._1, x._2)))
     }
 
-  def _hdfsubreadToDetails(ds: Future[Option[HdfSubreadServiceDataSet]]): Future[Option[String]] =
+  private def hdfsubreadToDetails(ds: Future[Option[HdfSubreadServiceDataSet]]): Future[Option[String]] =
     ds.map(_.map(x => DataSetJsonUtils.hdfSubreadSetToJson(DataSetLoader.loadHdfSubreadSet(Paths.get(x.path)))))
 
-  def getHdfDataSetDetailsById(id: Int): Future[Option[String]] = _hdfsubreadToDetails(getHdfDataSetById(id))
+  def getHdfDataSetDetailsById(id: Int): Future[Option[String]] = hdfsubreadToDetails(getHdfDataSetById(id))
 
-  def getHdfDataSetDetailsByUUID(uuid: UUID): Future[Option[String]] = _hdfsubreadToDetails(getHdfDataSetByUUID(uuid))
+  def getHdfDataSetDetailsByUUID(uuid: UUID): Future[Option[String]] = hdfsubreadToDetails(getHdfDataSetByUUID(uuid))
 
   def getHdfDataSetByUUID(id: UUID): Future[Option[HdfSubreadServiceDataSet]] =
     dal.db.run {
@@ -831,13 +831,13 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
       q.result.headOption.map(_.map(x => toB(x._1)))
     }
 
-  def _barcodeSetToDetails(ds: Future[Option[BarcodeServiceDataSet]]): Future[Option[String]] = {
+  private def barcodeSetToDetails(ds: Future[Option[BarcodeServiceDataSet]]): Future[Option[String]] = {
     ds.map(_.map(x => DataSetJsonUtils.barcodeSetToJson(DataSetLoader.loadBarcodeSet(Paths.get(x.path)))))
   }
 
-  def getBarcodeDataSetDetailsById(id: Int): Future[Option[String]] = _barcodeSetToDetails(getBarcodeDataSetById(id))
+  def getBarcodeDataSetDetailsById(id: Int): Future[Option[String]] = barcodeSetToDetails(getBarcodeDataSetById(id))
 
-  def getBarcodeDataSetDetailsByUUID(uuid: UUID): Future[Option[String]] = _barcodeSetToDetails(getBarcodeDataSetByUUID(uuid))
+  def getBarcodeDataSetDetailsByUUID(uuid: UUID): Future[Option[String]] = barcodeSetToDetails(getBarcodeDataSetByUUID(uuid))
 
   def toDataStoreJobFile(x: DataStoreServiceFile) =
     // This is has the wrong job uuid

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/tools/SetupMockData.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/tools/SetupMockData.scala
@@ -83,7 +83,7 @@ trait MockUtils extends LazyLogging{
 
   def insertMockJobs(): Future[Option[Int]] = {
     import scala.util.{Success, Failure}
-    def _toJob(n: Int) = EngineJob(
+    def toJob(n: Int) = EngineJob(
         n,
         UUID.randomUUID(),
         s"Job name $n",
@@ -96,7 +96,7 @@ trait MockUtils extends LazyLogging{
         "{}",
         Some("root")
     )
-    dao.dal.db.run(engineJobs ++= (1 until _MOCK_NJOBS).map(_toJob))
+    dao.dal.db.run(engineJobs ++= (1 until _MOCK_NJOBS).map(toJob))
   }
 
   def insertMockSubreadDataSetsFromDir(): Future[Seq[String]] = {
@@ -142,7 +142,7 @@ trait MockUtils extends LazyLogging{
   }
 
   def insertMockAlignmentDataSets(): Future[Seq[String]] = {
-    def _toDS(n: Int) = {
+    def toDS(n: Int) = {
       val uuid = UUID.randomUUID()
       AlignmentServiceDataSet(n,
         UUID.randomUUID(),
@@ -156,7 +156,7 @@ trait MockUtils extends LazyLogging{
         "mock Alignment Dataset comments",
         "mock-alignment-dataset-tags", toMd5(uuid.toString), _MOCK_USER_ID, _MOCK_JOB_ID, _MOCK_PROJECT_ID)
     }
-    val dss = (1 until _MOCK_NDATASETS).map(_toDS)
+    val dss = (1 until _MOCK_NDATASETS).map(toDS)
     Future.sequence(dss.map(dao.insertAlignmentDataSet))
   }
 

--- a/smrt-server-link/src/main/scala/db/migration/V1__InitialSchema.scala
+++ b/smrt-server-link/src/main/scala/db/migration/V1__InitialSchema.scala
@@ -12,7 +12,7 @@ import slick.lifted.ProvenShape
 
 import scala.concurrent.Future
 
-
+// scalastyle:off
 class V1__InitialSchema extends JdbcMigration with SlickMigration with LazyLogging {
 
   override def slickMigrate(db: DatabaseDef): Future[Any] = {
@@ -71,6 +71,7 @@ class V1__InitialSchema extends JdbcMigration with SlickMigration with LazyLoggi
     )
   }
 }
+// scalastyle:on
 
 object InitialSchema extends PacBioDateTimeDatabaseFormat {
 


### PR DESCRIPTION
> WIP: not yet ready for merge.

Continues #95 and adds style checking for expected naming conventions. 

Adds naming style checks: Class, Object, Package, Method

Ignores a few easy-to-check items because it isn't clear from the style specs if this is needed. We can decide for our code base some other time.

- Enforce a single space before and after `+` symbols
- Enforce no whitespace at the end of lines