### PR TITLE
import the original referenceset, import subreadset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ smrt-server-analysis/db/*
 smrt-server-analysis/jobs-root
 
 test-data/*
+test-output/*
 
 # sbt specific
 .cache


### PR DESCRIPTION
Import subreadset as part of the stress test.
Also, if the test referenceset had been imported with the original UUID, stress.py would run successfully, but if not, then then the dev_diagnostic pipeline would fail to run because it expected the original referenceset UUID.