### PR TITLE
use task ID as report type ID

### DIFF
--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -535,7 +535,7 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
         .filter(_.jobId === jobId)
         .filter(_.fileTypeId === FileTypes.REPORT.fileTypeId)
         .result
-    }.map(_.map(DataStoreReportFile(_, "mock-report-type-id")))
+    }.map(_.map((d: DataStoreServiceFile) => DataStoreReportFile(d, d.sourceId.split("-").head)))
 
   // Return the contents of the Report
   def getDataStoreReportByUUID(reportUUID: UUID): Future[Option[String]] = {


### PR DESCRIPTION
@mpkocher alternatively, we could further split the task ID by '.' and take the last element, so 'mapping_stats', 'ccs_report', and so on