### PR TITLE
fasta-to-gmap-reference: copy input fasta to new location before creating indices

### DIFF
--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/externaltools/CallGmapBuild.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/externaltools/CallGmapBuild.scala
@@ -13,20 +13,21 @@ object CallGmapBuild extends ExternalToolsUtils{
   val EXE = "gmap_build"
   lazy val CWD = Paths.get(".")
 
-  def apply(fastaPath: Path, refName: String, outputDir: Path = CWD,
+  def apply(fastaPath: Path,
+            outputDir: Path = CWD,
             gmapBuildExePath: String = EXE): Option[ExternalCmdFailure] = {
     val cmd = Seq(gmapBuildExePath, "-D", outputDir.toAbsolutePath.toString,
-                  "-d", refName, fastaPath.toAbsolutePath.toString)
+                  "-d", "gmap_db", fastaPath.toAbsolutePath.toString)
     runSimpleCmd(cmd)
   }
 
-  def run(fastaPath: Path, refName: String, outputDir: Path = CWD,
+  def run(fastaPath: Path,
+          outputDir: Path = CWD,
           gmapBuildExePath: String = EXE): Either[ExternalCmdFailure, Path] = {
     // the output directory will be $refName in $PWD
-    val dbPath = Paths.get(refName)
-    apply(fastaPath, refName, outputDir, gmapBuildExePath) match {
+    apply(fastaPath, outputDir, gmapBuildExePath) match {
       case Some(e) => Left(e)
-      case _ => Right(dbPath)
+      case _ => Right(outputDir.resolve("gmap_db"))
     }
   }
 }

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/tools/FastaToGmapReferenceSet.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/tools/FastaToGmapReferenceSet.scala
@@ -18,7 +18,8 @@ case class FastaToGmapReferenceSetConfig(
     outputDir: String,
     name: String,
     organism: String,
-    ploidy: String) extends LoggerConfig
+    ploidy: String,
+    inPlace: Boolean = false) extends LoggerConfig
 
 object FastaToGmapReferenceSet extends CommandLineToolRunner[FastaToGmapReferenceSetConfig] {
 
@@ -51,6 +52,10 @@ object FastaToGmapReferenceSet extends CommandLineToolRunner[FastaToGmapReferenc
       c.copy(ploidy = x)
     } text "ploidy "
 
+    opt[Unit]("in-place") action { (x, c) =>
+      c.copy(inPlace = true)
+    } text "Don't copy input FASTA file to output location"
+
     LoggerOptions.add(this.asInstanceOf[OptionParser[LoggerConfig]])
 
     opt[Unit]('h', "help") action { (x, c) =>
@@ -67,7 +72,7 @@ object FastaToGmapReferenceSet extends CommandLineToolRunner[FastaToGmapReferenc
     val organism = Option(c.organism)
 
     Try {
-      GmapReferenceConverter(c.name, fastaPath, outputDir, organism, ploidy)
+      GmapReferenceConverter(c.name, fastaPath, outputDir, organism, ploidy, c.inPlace)
     } match {
       case Success(x) => x match {
         case Right(rs) =>


### PR DESCRIPTION
Mimicking the behavior of fasta-to-reference