### PR TITLE
workaround for ID vs. UUID inconsistency in entry point JSON

### DIFF
--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/jobtypes/PbsmrtpipeServiceJobType.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/services/jobtypes/PbsmrtpipeServiceJobType.scala
@@ -98,7 +98,7 @@ class PbsmrtpipeServiceJobType(
               val uuid = UUID.randomUUID()
               logger.info(s"Attempting to create pbsmrtpipe Job ${uuid.toString} from service options $ropts")
 
-              val fsx = ropts.entryPoints.map(x => ValidateImportDataSetUtils.resolveDataSet(x.fileTypeId, x.datasetId, dbActor))
+              val fsx = ropts.entryPoints.map(x => ValidateImportDataSetUtils.resolveDataSetByAny(x.fileTypeId, x.datasetId, dbActor))
 
               val pathsFs = Future sequence fsx
               val rs = Await.result(pathsFs, 4.seconds)

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/PbService.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/PbService.scala
@@ -560,7 +560,7 @@ class PbService (val sal: AnalysisServiceAccessLayer,
 
   def runEmitAnalysisTemplate: Int = {
     val analysisOpts = {
-      val ep = BoundServiceEntryPoint("eid_subread", "PacBio.DataSet.SubreadSet", 1)
+      val ep = BoundServiceEntryPoint("eid_subread", "PacBio.DataSet.SubreadSet", Left(0))
       val eps = Seq(ep)
       val taskOptions = Seq[ServiceTaskOptionBase]()
       val workflowOptions = Seq[ServiceTaskOptionBase]()
@@ -587,7 +587,7 @@ class PbService (val sal: AnalysisServiceAccessLayer,
   protected def validateEntryPoints(entryPoints: Seq[BoundServiceEntryPoint]): Int = {
     for (entryPoint <- entryPoints) {
       Try {
-        Await.result(sal.getDataSetById(entryPoint.datasetId), TIMEOUT)
+        Await.result(sal.getDataSetByAny(entryPoint.datasetId), TIMEOUT)
       } match {
         case Success(dsInfo) => {
           // TODO check metatype against input
@@ -647,7 +647,7 @@ class PbService (val sal: AnalysisServiceAccessLayer,
       case Success(ds) => ds.id
       case Failure(err) => throw new Exception(err.getMessage)
     }
-    BoundServiceEntryPoint(eid, dsType, dsId)
+    BoundServiceEntryPoint(eid, dsType, Left(dsId))
   }
 
   protected def importEntryPointAutomatic(entryPoint: String): BoundServiceEntryPoint = {

--- a/smrt-server-analysis/src/test/scala/JobExecutorSpecBase.scala
+++ b/smrt-server-analysis/src/test/scala/JobExecutorSpecBase.scala
@@ -83,7 +83,7 @@ with JobServiceConstants {
   def toJobType(x: String) = s"/$ROOT_SERVICE_PREFIX/job-manager/jobs/$x"
 
   val mockOpts = {
-    val ep = BoundServiceEntryPoint("e_01", "DataSet.Subread.", 1)
+    val ep = BoundServiceEntryPoint("e_01", "DataSet.Subread.", Left(1))
     val eps = Seq(ep)
     val taskOptions = Seq[ServiceTaskOptionBase]()
     val workflowOptions = Seq[ServiceTaskOptionBase]()

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/Models.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/Models.scala
@@ -151,7 +151,7 @@ case class JobTypeEndPoint(jobTypeId: String, description: String) {
 
 // Entry point use to create jobs from the Service layer. This will then be translated to a
 // BoundEntryPoint with the resolved path of the DataSet
-case class BoundServiceEntryPoint(entryId: String, fileTypeId: String, datasetId: Int)
+case class BoundServiceEntryPoint(entryId: String, fileTypeId: String, datasetId: Either[Int,UUID])
 
 // Entry points that are have dataset types
 case class EngineJobEntryPoint(jobId: Int, datasetUUID: UUID, datasetType: String)

--- a/smrt-server-link/src/test/scala/JobExecutorSpec.scala
+++ b/smrt-server-link/src/test/scala/JobExecutorSpec.scala
@@ -99,7 +99,7 @@ with JobServiceConstants {
   val mockOpts = PbSmrtPipeServiceOptions(
     "My-job-name",
     "pbsmrtpipe.pipelines.mock_dev01",
-    Seq(BoundServiceEntryPoint("e_01", "PacBio.DataSet.SubreadSet", 1)),
+    Seq(BoundServiceEntryPoint("e_01", "PacBio.DataSet.SubreadSet", Left(1))),
     Nil,
     Nil)
 


### PR DESCRIPTION
The change to ValidateImportDataSetUtils.scala is a bit hacky - I was trying to avoid changing anything relating to the database