### PR TITLE
Match Python CLI-style params

### DIFF
--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
@@ -30,7 +30,7 @@ object LoggerOptions {
     } text "Level for logging: \"ERROR\", \"WARN\", \"DEBUG\", or \"INFO\". Default is \"ERROR\""
 
     for ((n, l) <- List(("debug", "DEBUG"), ("quiet", "ERROR"), ("verbose", "INFO")))
-      parser.opt[String](n) action { (x, c) =>
+      parser.opt[Unit](n) action { (x, c) =>
         c.configure(c.logbackFile, c.logFile, c.debug, l)
       } text s"Same as --log-level $l"
 

--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
@@ -25,11 +25,16 @@ object LoggerOptions {
       c.configure(c.logbackFile, c.logFile, true, c.logLevel)
     } text "If true, log output will be displayed to the console. Default is false."
 
-    parser.opt[String]("loglevel") action { (x, c) =>
+    parser.opt[String]("log-level") action { (x, c) =>
       c.configure(c.logbackFile, c.logFile, c.debug, x)
     } text "Level for logging: \"ERROR\", \"WARN\", \"DEBUG\", or \"INFO\". Default is \"ERROR\""
 
-    parser.opt[String]("logfile") action { (x, c) =>
+    for ((n, l) <- List(("debug", "DEBUG"), ("quiet", "ERROR"), ("verbose", "INFO")))
+      parser.opt[String](n) action { (x, c) =>
+        c.configure(c.logbackFile, c.logFile, c.debug, l)
+      } text s"Same as --log-level $l"
+
+    parser.opt[String]("log-file") action { (x, c) =>
       c.configure(c.logbackFile, x, c.debug, c.logLevel)
     } text "File for log output. Default is \".\""
 


### PR DESCRIPTION
CC @natechols @mpkocher @skinner 

Fixes #186 

@skinner Heads up that I changed `--logfile` to match `--log-file` in the python CLI params. This will mean that any deploy script that sets the file via `--logfile` will need to add the hyphen. Please confirm we're good to merge with this edit.

You can make/run this code similar to #111. 

```
# rebuild the JAR needed for command-line use
sbt clean compile smrt-server-analysis/assembly

# run the analysis server from command line
$ sbt "smrt-server-analysis/run --help"
...
[info] Running com.pacbio.secondary.smrtserver.appcomponents.SecondaryAnalysisServer --help
[info] Usage: ./app_with_logging [options]
[info] 
[info] This is an app that supports PacBio logging flags. 
[info]   -h | --help
[info]         Show Options and exit
[info]   --log2stdout
[info]         If true, log output will be displayed to the console. Default is false.
[info]   --log-level <value>
[info]         Level for logging: "ERROR", "WARN", "DEBUG", or "INFO". Default is "ERROR"
[info]   --debug
[info]         Same as --log-level DEBUG
[info]   --quiet
[info]         Same as --log-level ERROR
[info]   --verbose
[info]         Same as --log-level INFO
[info]   --log-file <value>
[info]         File for log output. Default is "."
[info]   --logback <value>
[info]         Override all logger config with the given logback.xml file.
```

Try the new `--debug` flag to see INFO level (same as default, no flags).

```
$ sbt "smrt-server-analysis/run --debug"
[info] Loading project definition from /Users/jfalkner/tokeep/git/PacificBiosciences/smrtflow/project
[info] Set current project to smrtflow (in build file:/Users/jfalkner/tokeep/git/PacificBiosciences/smrtflow/)
[info] Running com.pacbio.secondary.smrtserver.appcomponents.SecondaryAnalysisServer --debug
[info] 2016-06-21  INFO [main] c.p.s.s.a.SecondaryAnalysisServer$ - Starting App
[info] 2016-06-21  INFO [main] c.p.s.s.a.SecondaryAnalysisServer$ - Java Version: 1.8.0_92
...
```

Or just ERROR messages.

```
$ sbt "smrt-server-analysis/run --quiet"
...
[error] [WARNING] Unable to load CMD template from pb-engine.pb-cmd-template Error No configuration setting found for key 'pb-engine.pb-cmd-template'
```

etc...

## Testing

No test suite yet. Working to add a minimal one.