### PR TITLE
Guard for nested queries

### DIFF
--- a/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
@@ -135,6 +135,9 @@ class Database(dbURI: String) {
     }
   }
 
+
+  var queryCount = 0
+
   /**
    * Runs DBIOAction instances on the underlying SQLite RDMS
    *
@@ -162,10 +165,15 @@ class Database(dbURI: String) {
     // track timing for queue wait and RBMS execution
     val start: Long = if (dbug) System.currentTimeMillis() else 0
     // track what code is doing DB access (stack trace outside of the execution context)
-    val stacktrace = if(dbug) new Exception("RDMS Query Tracking") else null
-    val code = if(dbug) stacktrace.getStackTrace()(1).toString else null
+    val stacktrace = if (dbug) new Exception("RDMS Query Tracking") else null
+    val code = if (dbug) stacktrace.getStackTrace()(1).toString else null
+    Future { listeners.foreach(_.create(code, stacktrace)) }
+    // main wrapper for running the query and blocking with timeout for detecting SQLite related issues
     Future[R] {
       try {
+        // tally how many db.run() are being invoked -- TODO: can remove queryCount entirely?
+        queryCount += 1
+        Future { listeners.foreach(_.start(code, stacktrace, queryCount)) }
         // track RMDS execution timing
         val startRDMS: Long = if (dbug) System.currentTimeMillis() else 0
         // run the SQL and wait for it is execute
@@ -173,31 +181,46 @@ class Database(dbURI: String) {
         if (dbug) {
           // tool the future to dump failure reasons
           f onFailure {
-            case t => listeners.foreach(_.error(code, stacktrace, t))
+            case t => Future { listeners.foreach(_.error(code, stacktrace, t)) }
           }
           // tool the future to dump failure reasons
           f onSuccess {
-            case x => listeners.foreach(_.success(code, stacktrace, x))
+            case x => Future { listeners.foreach(_.success(code, stacktrace, x)) }
           }
         }
-        val toreturn = Await.result(f, 10 seconds) // TODO: config via param
+        val toreturn = Await.result(f, 12345 milliseconds) // TODO: config via param
         // track RDBMS execution timing
         val endRDMS: Long = if (dbug) System.currentTimeMillis() else 0
-        listeners.foreach(_.dbDone(startRDMS, endRDMS, code, stacktrace))
+        Future { listeners.foreach(_.dbDone(startRDMS, endRDMS, code, stacktrace)) }
         toreturn
       }
+      catch {
+        case t => {
+          Future {
+            listeners.foreach(_.timeout(code, stacktrace, new Exception("Nested db.run() calls?", t)))
+          }
+          throw t
+        }
+      }
       finally {
+        // decrement query count
+        queryCount -= 1
+        Future { listeners.foreach(_.end(code, stacktrace, queryCount)) }
+
         val end: Long = if (dbug) System.currentTimeMillis() else 0
         // track timing for queue and RDMS execution
-        listeners.foreach(_.allDone(start, end, code, stacktrace))
-        val conn = connectionPool.cachedConnection
-        if (!conn.isClosed)
-          try {
-            conn.commit()
-            conn.close()
-          } catch {
-            case ex: Throwable => println("Ignoring commit()/close() fail: " + ex)
-          }
+        Future { listeners.foreach(_.allDone(start, end, code, stacktrace)) }
+        // only force close if all (sub-)queries are done
+        if (queryCount == 0) {
+          val conn = connectionPool.cachedConnection
+          if (!conn.isClosed)
+            try {
+              conn.commit()
+              conn.close()
+            } catch {
+              case ex: Throwable => println("Ignoring commit()/close() fail: " + ex)
+            }
+        }
       }
       // share the execution context the DB uses
     } (dec)

--- a/smrt-server-database/src/main/scala/com/pacbio/database/DatabaseListener.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/DatabaseListener.scala
@@ -4,6 +4,12 @@ package com.pacbio.database
  * Created by jfalkner on 6/10/16.
  */
 trait DatabaseListener {
+  // life cycle of the nested Future. useful for debugging nested db.run use
+  def create(code: String, stacktrace: Throwable): Unit
+  def start(code: String, stacktrace: Throwable, queryCount: Int): Unit
+  def end(code: String, stacktrace: Throwable, queryCount: Int): Unit
+  // summary and query status
+  def timeout(code: String, stacktrace: Throwable, t: Throwable): Unit
   def error(code: String, stacktrace: Throwable, t: Throwable): Unit
   def success(code: String, stacktrace: Throwable, result: Any): Unit
   def dbDone(start: Long, end: Long, code: String, stacktrace: Throwable): Unit

--- a/smrt-server-database/src/main/scala/com/pacbio/database/LoggingListener.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/LoggingListener.scala
@@ -9,6 +9,21 @@ class LoggingListener extends DatabaseListener with LazyLogging {
 
   val Prefix = "[PacBio:Database] "
 
+
+  // life cycle of the nested Future. useful for debugging nested db.run use
+  override def create(code: String, stacktrace: Throwable): Unit =
+    logger.error(s"$Prefix RDMS created DBIOAction $code")
+  override def start(code: String, stacktrace: Throwable, qc: Int): Unit =
+    logger.error(s"$Prefix RDMS started DBIOAction $code, queryCount = $qc")
+  override def end(code: String, stacktrace: Throwable, qc: Int): Unit =
+    logger.error(s"$Prefix RDMS finished DBIOAction $code, queryCount = $qc")
+
+  override def timeout(
+      code: String,
+      stacktrace: Throwable,
+      t: Throwable): Unit =
+    logger.error(s"$Prefix RDMS timeout for $code", t)
+
   override def error(
       code: String,
       stacktrace: Throwable,

--- a/smrt-server-database/src/main/scala/com/pacbio/database/LoggingListener.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/LoggingListener.scala
@@ -12,11 +12,11 @@ class LoggingListener extends DatabaseListener with LazyLogging {
 
   // life cycle of the nested Future. useful for debugging nested db.run use
   override def create(code: String, stacktrace: Throwable): Unit =
-    logger.error(s"$Prefix RDMS created DBIOAction $code")
+    logger.error(s"$Prefix created DBIOAction $code")
   override def start(code: String, stacktrace: Throwable, qc: Int): Unit =
-    logger.error(s"$Prefix RDMS started DBIOAction $code, queryCount = $qc")
+    logger.error(s"$Prefix started DBIOAction $code, queryCount = $qc")
   override def end(code: String, stacktrace: Throwable, qc: Int): Unit =
-    logger.error(s"$Prefix RDMS finished DBIOAction $code, queryCount = $qc")
+    logger.error(s"$Prefix finished DBIOAction $code, queryCount = $qc")
 
   override def timeout(
       code: String,

--- a/smrt-server-database/src/main/scala/com/pacbio/database/ProfilingListener.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/ProfilingListener.scala
@@ -8,6 +8,18 @@ class ProfilingListener extends DatabaseListener {
   var errors = Map[String, Int]()
   var complete = Map[String, Int]()
 
+  // life cycle of the nested Future. useful for debugging nested db.run use
+  override def create(code: String, stacktrace: Throwable): Unit = {}
+  override def start(code: String, stacktrace: Throwable, qc: Int): Unit = {}
+  override def end(code: String, stacktrace: Throwable, qc: Int): Unit = {}
+
+  override def timeout(
+      code: String,
+      stacktrace: Throwable,
+      t: Throwable): Unit = {
+    errors += (code -> (errors.getOrElse(code, 0) + 1))
+    printSummary
+  }
 
   override def error(
       code: String,


### PR DESCRIPTION
> WIP: need to flesh out docs and improve this description. Good to merge this PR when CircleCI is green. This code doesn't fix `stress.py`, rather it just shows how to see what DB calls need un-nesting. `unwrap_nested_db_run_usage` is the branch with the example fixes.

CC @mpkocher @skinner 

This includes some DB debugging improvements that I used to help clarify the nested query issue that appears to be the root cause of #161.

Running this branch should trigger the new guard that shows a more informative error such as the following, which notes that `insertDataStoreByJob` at `JobsDao.scala:505` timed out probably due to nested queries.

```
[info] 2016-06-22  ERROR[ForkJoinPool-2-worker-1] c.p.d.LoggingListener - [PacBio:Database]  RDMS timeout for com.pacbio.secondary.smrtlink.actors.DataSetStore$class.insertDataStoreByJob(JobsDao.scala:505)
[info] java.lang.Exception: Nested db.run() calls?
[info] 	at com.pacbio.database.Database$$anonfun$run$2$$anonfun$apply$3$$anonfun$apply$mcV$sp$6.apply(Database.scala:200)
[info] 	at com.pacbio.database.Database$$anonfun$run$2$$anonfun$apply$3$$anonfun$apply$mcV$sp$6.apply(Database.scala:200)
[info] 	at scala.collection.immutable.List.foreach(List.scala:381)
[info] 	at com.pacbio.database.Database$$anonfun$run$2$$anonfun$apply$3.apply$mcV$sp(Database.scala:200)
[info] 	at com.pacbio.database.Database$$anonfun$run$2$$anonfun$apply$3.apply(Database.scala:200)
[info] 	at com.pacbio.database.Database$$anonfun$run$2$$anonfun$apply$3.apply(Database.scala:200)
[info] 	at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
[info] 	at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
[info] 	at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:121)
[info] 	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
[info] 	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
[info] 	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
[info] 	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
[info] Caused by: java.util.concurrent.TimeoutException: Futures timed out after [12345 milliseconds]
[info] 	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:219)
[info] 	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:223)
[info] 	at scala.concurrent.Await$$anonfun$result$1.apply(package.scala:190)
[info] 	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:53)
[info] 	at scala.concurrent.Await$.result(package.scala:190)
[info] 	at com.pacbio.database.Database$$anonfun$run$2.apply(Database.scala:191)
[info] 	at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
[info] 	at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
[info] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[info] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[info] 	at java.lang.Thread.run(Thread.java:745)
```

I don't believe the above error can accurately assert nested queries even though they are the culprit in this case.

The logs further dump creation, start and end for `db.run` use. Here is some suspicious use that matches the above error. Expected output is to see in serial that a `DBIOAction` wrapper is created, started then finished before the next starts. See that `insertDataStoreByJob` weirdly has `getDataSetMetaDataSet` before it (it is invoked by it though) and then a bunch of new wrappers `created` before it finishes.

```
[PacBio:Database]  finished DBIOAction c.p.s.s.a.DataSetStore$class.getDataSetMetaDataSet(JobsDao.scala:554), queryCount = 0
[PacBio:Database]  started DBIOAction c.p.s.s.a.DataSetStore$class.insertDataStoreByJob(JobsDao.scala:505), queryCount = 1
[PacBio:Database]  created DBIOAction c.p.s.s.a.DataSetStore$$anonfun$insertReferenceDataSet$1.apply(JobsDao.scala:572)
[PacBio:Database]  created DBIOAction c.p.s.s.a.JobDataStore$class.updateJobStateByUUID(JobsDao.scala:299)
[PacBio:Database]  created DBIOAction c.p.s.s.a.JobDataStore$class.getJobById(JobsDao.scala:231)
[PacBio:Database]  created DBIOAction c.p.s.s.a.JobDataStore$class.getJobById(JobsDao.scala:231)
[PacBio:Database]  created DBIOAction c.p.s.s.a.JobDataStore$class.getJobById(JobsDao.scala:231)
[PacBio:Database]  created DBIOAction c.p.s.s.a.JobDataStore$class.getJobById(JobsDao.scala:231)
[PacBio:Database]  created DBIOAction c.p.s.s.a.JobDataStore$class.getJobById(JobsDao.scala:231)
[PacBio:Database]  created DBIOAction c.p.s.s.a.JobDataStore$class.getJobById(JobsDao.scala:231)
[PacBio:Database]  created DBIOAction c.p.s.s.a.JobDataStore$class.getJobById(JobsDao.scala:231)
```

I think the above behavior is really bad and explains the root cause of the lockups, SQLITE_BUSY errors and why `stress.py` fails on `master`. I'll post more notes tomorrow.