### PR TITLE
database and services support for GmapReferenceSet

### DIFF
--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/datasets/DataSetModels.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/datasets/DataSetModels.scala
@@ -71,7 +71,7 @@ object DataSetMetaTypes {
 
   case object GmapReference extends DataSetMetaType {
     final val fileType = FileTypes.DS_GMAP_REF
-    override def shortName = "gmap_references"
+    override def shortName = "gmapreferences"
   }
 
   // FIXME. The order is important. Will reuse this in the db

--- a/smrt-server-link/src/main/resources/schemas/datasets/gmapreference.schema.json
+++ b/smrt-server-link/src/main/resources/schemas/datasets/gmapreference.schema.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "pacbio.secondary.schemas.datasets.references",
+    "version": "1.0.0",
+    "title": "GmapReference",
+    "description": "GMAP Reference DataSet Schema",
+    "type": "object",
+    "properties": {
+
+        "id": {
+            "title": "UUID",
+            "description": "UUID of the GMAP Reference DataSet XML",
+            "type": "string",
+            "format": "uuid",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "readOnly": true
+        },
+        "name": {
+            "title": "Reference",
+            "description": "Name of this Reference",
+            "type": "string",
+            "minLength": 1,
+            "readOnly": true
+        },
+        "createdAt": {
+            "title": "Created at",
+            "description": "Time when the DataSet XML was created",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+        },
+        "version": {
+            "title": "Version",
+            "description": "Version of this DataSet XML",
+            "type": "string",
+            "format": "sem-ver",
+            "minLength": 5,
+            "readOnly": true
+        },
+        "numRecords": {
+            "title": "Num records",
+            "description": "Number of references in this DataSet",
+            "type": "integer",
+            "minimum": 0,
+            "readOnly": true
+        },
+        "totalLength": {
+            "title": "Total length",
+            "description": "Total length of references (in bp) in this DataSet",
+            "type": "integer",
+            "minimum": 0,
+            "readOnly": true
+        },
+        "tags": {
+            "title": "DataSet tags",
+            "description": "Tags assigned to the DataSet upon creation.",
+            "type": "array",
+            "items": { "type": "string", "readOnly": true },
+            "uniqueItems": true
+        },
+
+
+        "organism": {
+            "title": "Organism",
+            "description": "Scientific name of the organism for this reference",
+            "type": "string",
+            "readOnly": true
+        },
+        "ploidy": {
+            "title": "Ploidy",
+            "description": "Ploidy (1 if unknown) of this reference",
+            "type": "integer",
+            "enum": [0, 1, 2],
+            "readOnly": true
+        },
+
+
+        "path": {
+            "title": "DataSet path",
+            "description": "Path to GMAP Reference DataSet XML",
+            "type": "string",
+            "format": "uri",
+            "readOnly": true
+        },
+        "description": {
+            "title": "Comments",
+            "description": "User description and comments",
+            "type": "string"
+        },
+        "importedAt": {
+            "title": "Imported at",
+            "description": "Time when DataSet was imported",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+        },
+        "modifiedAt": {
+            "title": "Updated at",
+            "description": "Time when DataSet metadata was last updated",
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+        },
+        "status": {
+            "title": "DataSet Status",
+            "description": "Status of DataSet (New, Pending, Complete, Error). For 3.0.0-rc1 all DataSets will be Complete",
+            "type": "string",
+            "enum": ["New", "Pending", "Complete", "Error"],
+            "readOnly": true
+        },
+        "md5": {
+            "title": "md5", 
+            "description": "md5 checksum of the Dataset XML file",
+            "type": "string",
+            "format": "md5",
+            "pattern": "^[a-fA-F0-9]{32}$",
+            "readOnly": true
+        },
+        "parentAnalysisJobId": {
+            "title": "Parent Job Id",
+            "description": "Id of job that generated this DataSet",
+            "type": "integer",
+            "minimum": 0,
+            "readOnly": true
+        },
+        "userId": {
+            "title": "User Id",
+            "description": "User Id that imported the DataSet",
+            "type": "string",
+            "minLength": 1,
+            "readOnly": true
+        },
+        "smrtanalysisInstallId": {
+            "title": "SMRT Analysis Installation Id",
+            "description": "Installation that the DataSet belongs to. TODO in DataModel?",
+            "type": "string",
+            "format": "uuid",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "readOnly": true
+        },
+        "projectId": {
+            "title": "Project Id",
+            "description": "Project that the DataSet belongs to. TODO in DataModel?",
+            "type": "string",
+            "format": "uuid",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+            "readOnly": true
+        },
+        "serviceTags": {
+            "title": "User defined tags",
+            "description": "Tags defined and set at the services level",
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true
+        }
+    },
+
+    "required": [   
+        "id", 
+        "name", 
+        "createdAt", 
+        "version", 
+        "numRecords", 
+        "totalLength", 
+        "tags",  
+
+        "organism", 
+        "ploidy", 
+
+        "path", 
+        "description", 
+        "importedAt", 
+        "modifiedAt", 
+        "status", 
+        "md5",
+        "parentAnalysisJobId",
+        "userId",
+        "smrtanalysisInstallId",
+        "projectId",
+        "serviceTags"
+    ],
+
+    "additionalProperties": false
+}

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -459,6 +459,10 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
         val dataset = DataSetLoader.loadReferenceSet(path)
         val sds = Converters.convert(dataset, path.toAbsolutePath, userId, jobId, projectId)
         insertReferenceDataSet(sds)
+      case DataSetMetaTypes.GmapReference =>
+        val dataset = DataSetLoader.loadGmapReferenceSet(path)
+        val sds = Converters.convert(dataset, path.toAbsolutePath, userId, jobId, projectId)
+        insertGmapReferenceDataSet(sds)
       case DataSetMetaTypes.HdfSubread =>
         val dataset = DataSetLoader.loadHdfSubreadSet(path)
         val sds = Converters.convert(dataset, path.toAbsolutePath, userId, jobId, projectId)
@@ -576,6 +580,26 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
             dsReference2 forceInsert ReferenceServiceSet(id, ds.uuid, ds.ploidy, ds.organism)
           }.map { _ =>
             val m = s"imported ReferencecSet ${ds.uuid} from ${ds.path}"
+            logger.info(m)
+            m
+          }
+        }
+    }
+
+  def insertGmapReferenceDataSet(ds: GmapReferenceServiceDataSet): Future[String] =
+    getDataSetMetaDataSet(ds.uuid).flatMap {
+      case Some(_) =>
+        val msg = s"GmapReferenceSet ${ds.uuid} already imported. Skipping importing of $ds"
+        logger.debug(msg)
+        Future(msg)
+      case None =>
+        db.run {
+          insertMetaData(ds).flatMap { id =>
+            // TODO(smcclellan): Here and below, remove use of forceInsert and allow ids to make use of autoinc
+            // TODO(smcclellan): Link datasets to metadata with foreign key, rather than forcing the id value
+            dsGmapReference2 forceInsert GmapReferenceServiceSet(id, ds.uuid, ds.ploidy, ds.organism)
+          }.map { _ =>
+            val m = s"imported GmapReferencecSet ${ds.uuid} from ${ds.path}"
             logger.info(m)
             m
           }
@@ -717,6 +741,35 @@ trait DataSetStore extends DataStoreComponent with LazyLogging {
     db.run {
       val q = datasetMetaTypeByUUID(id) join dsReference2 on (_.id === _.id)
       q.result.headOption.map(_.map(x => toR(x._1, x._2)))
+    }
+
+  def toGmapR(t1: DataSetMetaDataSet, t2: GmapReferenceServiceSet): GmapReferenceServiceDataSet =
+    GmapReferenceServiceDataSet(t1.id, t1.uuid, t1.name, t1.path, t1.createdAt, t1.updatedAt, t1.numRecords, t1.totalLength,
+      t1.version, t1.comments, t1.tags, t1.md5, t1.userId, t1.jobId, t1.projectId, t2.ploidy, t2.organism)
+
+  def getGmapReferenceDataSets(limit: Int = DEFAULT_MAX_DATASET_LIMIT): Future[Seq[GmapReferenceServiceDataSet]] =
+    db.run {
+      val q = dsMetaData2 join dsGmapReference2 on (_.id === _.id)
+      q.result.map(_.map(x => toGmapR(x._1, x._2)))
+    }
+
+  def getGmapReferenceDataSetById(id: Int): Future[Option[GmapReferenceServiceDataSet]] =
+    db.run {
+      val q = datasetMetaTypeById(id) join dsGmapReference2 on (_.id === _.id)
+      q.result.headOption.map(_.map(x => toGmapR(x._1, x._2)))
+    }
+  private def gmapReferenceToDetails(ds: Future[Option[GmapReferenceServiceDataSet]]): Future[Option[String]] =
+    ds.map(_.map(x => DataSetJsonUtils.gmapReferenceSetToJson(DataSetLoader.loadGmapReferenceSet(Paths.get(x.path)))))
+
+  def getGmapReferenceDataSetDetailsById(id: Int): Future[Option[String]] = gmapReferenceToDetails(getGmapReferenceDataSetById(id))
+
+  def getGmapReferenceDataSetDetailsByUUID(uuid: UUID): Future[Option[String]] =
+    gmapReferenceToDetails(getGmapReferenceDataSetByUUID(uuid))
+
+  def getGmapReferenceDataSetByUUID(id: UUID): Future[Option[GmapReferenceServiceDataSet]] =
+    db.run {
+      val q = datasetMetaTypeByUUID(id) join dsGmapReference2 on (_.id === _.id)
+      q.result.headOption.map(_.map(x => toGmapR(x._1, x._2)))
     }
 
   def getHdfDataSets(limit: Int = DEFAULT_MAX_DATASET_LIMIT): Future[Seq[HdfSubreadServiceDataSet]] =

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/database/TableModels.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/database/TableModels.scala
@@ -292,6 +292,15 @@ object TableModels extends PacBioDateTimeDatabaseFormat {
     def * = (id, uuid, ploidy, organism) <>(ReferenceServiceSet.tupled, ReferenceServiceSet.unapply)
   }
 
+  class GmapReferenceDataSetT(tag: Tag) extends IdAbleTable[GmapReferenceServiceSet](tag, "dataset_gmapreferences") {
+
+    def ploidy: Rep[String] = column[String]("ploidy")
+
+    def organism: Rep[String] = column[String]("organism")
+
+    def * = (id, uuid, ploidy, organism) <>(GmapReferenceServiceSet.tupled, GmapReferenceServiceSet.unapply)
+  }
+
   class AlignmentDataSetT(tag: Tag) extends IdAbleTable[AlignmentServiceSet](tag, "datasets_alignments") {
     def * = (id, uuid) <>(AlignmentServiceSet.tupled, AlignmentServiceSet.unapply)
   }
@@ -485,6 +494,7 @@ object TableModels extends PacBioDateTimeDatabaseFormat {
   lazy val dsAlignment2 = TableQuery[AlignmentDataSetT]
   lazy val dsBarcode2 = TableQuery[BarcodeDataSetT]
   lazy val dsCCSread2 = TableQuery[CCSreadDataSetT]
+  lazy val dsGmapReference2 = TableQuery[GmapReferenceDataSetT]
 
   lazy val datastoreServiceFiles = TableQuery[PacBioDataStoreFileT]
 
@@ -529,6 +539,7 @@ object TableModels extends PacBioDateTimeDatabaseFormat {
     dsAlignment2,
     dsBarcode2,
     dsCCSread2,
+    dsGmapReference2,
     datastoreServiceFiles)
 
   lazy val runTables: Set[SlickTable] = Set(runSummaries, dataModels, collectionMetadata)

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/loaders/SchemaLoader.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/loaders/SchemaLoader.scala
@@ -53,6 +53,7 @@ trait SchemaLoader extends LazyLogging{
   val ccsAlignmentSchema = loadAndRegister("pacbio.secondary.schemas.datasets.alignments", "ccs-alignment.schema.json")
   val ccsReadSchema = loadAndRegister("pacbio.secondary.schemas.datasets.ccsreads", "ccs-read.schema.json")
   val contigSchema = loadAndRegister("pacbio.secondary.schemas.datasets.contig", "contigs.schema.json")
+  val gmapReferenceSchema = loadAndRegister("pacbio.secondary.schemas.datasets.gmapreferences", "gmapreference.schema.json")
 }
 
 object SchemaLoader extends SchemaLoader

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/DataSetService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/DataSetService.scala
@@ -214,6 +214,14 @@ class DataSetService(dbActor: ActorRef) extends JobsBaseMicroService with SmrtLi
         GetReferenceDataSetByUUID,
         GetReferenceDataSetDetailsById,
         GetReferenceDataSetDetailsByUUID) ~
+      datasetRoutes[GmapReferenceServiceDataSet](
+        DataSetMetaTypes.GmapReference.shortName,
+        GetGmapReferenceDataSets,
+        SchemaLoader.gmapReferenceSchema.content,
+        GetGmapReferenceDataSetById,
+        GetGmapReferenceDataSetByUUID,
+        GetGmapReferenceDataSetDetailsById,
+        GetGmapReferenceDataSetDetailsByUUID) ~
       datasetRoutes[BarcodeServiceDataSet](
         DataSetMetaTypes.Barcode.shortName,
         GetBarcodeDataSets,

--- a/smrt-server-link/src/main/scala/db/migration/V12__GmapReferences.scala
+++ b/smrt-server-link/src/main/scala/db/migration/V12__GmapReferences.scala
@@ -1,0 +1,52 @@
+package db.migration
+
+import java.util.UUID
+
+import com.pacbio.common.time.PacBioDateTimeDatabaseFormat
+import com.typesafe.scalalogging.LazyLogging
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration
+import org.joda.time.{DateTime => JodaDateTime}
+import slick.driver.SQLiteDriver.api._
+import slick.jdbc.JdbcBackend.DatabaseDef
+import slick.lifted.ProvenShape
+
+import scala.concurrent.Future
+
+
+class V12__GmapReferences extends JdbcMigration with SlickMigration with LazyLogging {
+  override def slickMigrate(db: DatabaseDef): Future[Any] = {
+    db.run {
+      V12Schema.gmapReference.schema.create >> _populateGmapDataSetType
+    }
+  }
+
+  def _populateGmapDataSetType: DBIOAction[Any, NoStream, _ <: Effect] = {
+    val dsTypeRows = List(
+      ("PacBio.DataSet.GmapReferenceSet", "Display name for PacBio.DataSet.GmapReferenceSet", "Description for PacBio.DataSet.GmapReferenceSet", JodaDateTime.now(), JodaDateTime.now(), "gmapreferences")
+    )
+    InitialSchema.datasetTypes ++= dsTypeRows
+  }
+}
+
+
+object V12Schema extends PacBioDateTimeDatabaseFormat {
+
+  // XXX copied from initial schema...
+  abstract class IdAbleTable[T](tag: Tag, tableName: String) extends Table[T](tag, tableName) {
+    def id: Rep[Int] = column[Int]("id", O.PrimaryKey, O.AutoInc)
+
+    def uuid: Rep[UUID] = column[UUID]("uuid")
+  }
+
+  class GmapReferenceDataSetT(tag: Tag) extends IdAbleTable[(Int, UUID, String, String)](tag, "dataset_gmapreferences") {
+
+    def ploidy: Rep[String] = column[String]("ploidy")
+
+    def organism: Rep[String] = column[String]("organism")
+
+    def * : ProvenShape[(Int, UUID, String, String)] = (id, uuid, ploidy, organism)
+
+  }
+
+  lazy val gmapReference = TableQuery[GmapReferenceDataSetT]
+}


### PR DESCRIPTION
I think this works - enough that I can import a dataset and see it in `/secondary-analysis/datasets/gmapreferences`.  Are we unit-testing stuff like this or leaving it to integration tests?