### PR TITLE
models for new testkit config

### DIFF
--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/testkit/Models.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/testkit/Models.scala
@@ -37,7 +37,6 @@ object TestkitModels {
     pipelineId: Option[String],
     workflowXml: Option[String],
     presetXml: Option[String],
-    outputDir: Option[String], // XXX unused here
     entryPoints: Seq[EntryPointPath],
     reportTests: Seq[ReportTestRules])
 
@@ -74,7 +73,7 @@ trait TestkitJsonProtocol extends SmrtLinkJsonProtocols with SecondaryAnalysisJs
   }
 
   implicit val reportRulesFormat = jsonFormat2(ReportTestRules)
-  implicit val testkitConfigFormat = jsonFormat9(TestkitConfig)
+  implicit val testkitConfigFormat = jsonFormat8(TestkitConfig)
 }
 
 //object TestkitJsonProtocol extends TestkitJsonProtocol

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/testkit/Models.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/testkit/Models.scala
@@ -1,0 +1,80 @@
+
+package com.pacbio.secondary.smrtserver.testkit
+
+import java.nio.file.Path
+
+import spray.json._
+
+import com.pacbio.secondary.smrtserver.models._
+import com.pacbio.secondary.analysis.constants.FileTypes
+import com.pacbio.secondary.analysis.jobs.AnalysisJobStates
+import com.pacbio.secondary.analysis.jobs.JobModels._
+import com.pacbio.secondary.analysis.reports.ReportModels
+import com.pacbio.secondary.smrtlink.client._
+import com.pacbio.secondary.smrtlink.models._
+import com.pacbio.common.client._
+import com.pacbio.common.models._
+
+
+object TestkitModels {
+
+  case class EntryPointPath(entryId: String, path: Path)
+
+  abstract class ReportAttributeRule
+
+  case class ReportAttributeLongRule(attrId: String, op: String, value: Long) extends ReportAttributeRule
+
+  case class ReportAttributeDoubleRule(attrId: String, op: String, value: Double) extends ReportAttributeRule
+
+  case class ReportAttributeStringRule(attrId: String, value: String) extends ReportAttributeRule
+
+  case class ReportTestRules(reportId: String, rules: Seq[ReportAttributeRule])
+
+  case class TestkitConfig(
+    jobName: String,
+    jobType: String,
+    description: String,
+    pipelineId: Option[String],
+    workflowXml: Option[String],
+    presetXml: Option[String],
+    outputDir: Option[String], // XXX unused here
+    entryPoints: Seq[EntryPointPath],
+    reportTests: Seq[ReportTestRules])
+
+}
+
+trait TestkitJsonProtocol extends SmrtLinkJsonProtocols with SecondaryAnalysisJsonProtocols {
+
+  import TestkitModels._
+
+  implicit val entryPointPathFormat = jsonFormat2(EntryPointPath)
+  implicit val reportLongRuleFormat = jsonFormat3(ReportAttributeLongRule)
+  implicit val reportDoubleRuleFormat = jsonFormat3(ReportAttributeDoubleRule)
+  implicit val reportStringRuleFormat = jsonFormat2(ReportAttributeStringRule)
+
+  implicit object reportAttributeRuleFormat extends JsonFormat[ReportAttributeRule] {
+    def write(rar: ReportAttributeRule) = rar match {
+      case rlr: ReportAttributeLongRule => rlr.toJson
+      case rdr: ReportAttributeDoubleRule => rdr.toJson
+      case rsr: ReportAttributeStringRule => rsr.toJson
+    }
+
+    def read(jsRule: JsValue): ReportAttributeRule = {
+      jsRule.asJsObject.getFields("attrId", "op", "value") match {
+        case Seq(JsString(id), JsString(op), JsNumber(value)) => {
+          if (value.isValidInt) ReportAttributeLongRule(id, op, value.toLong)
+          else ReportAttributeDoubleRule(id, op, value.toDouble)
+        }
+        case _ => jsRule.asJsObject.getFields("attrId", "value") match {
+          case Seq(JsString(id), JsString(value)) => ReportAttributeStringRule(id, value)
+          case x => deserializationError(s"Expected attribute rule, got ${x}")
+        }
+      }
+    }
+  }
+
+  implicit val reportRulesFormat = jsonFormat2(ReportTestRules)
+  implicit val testkitConfigFormat = jsonFormat9(TestkitConfig)
+}
+
+//object TestkitJsonProtocol extends TestkitJsonProtocol

--- a/smrt-server-analysis/src/test/resources/testkit/testkit_cfg.json
+++ b/smrt-server-analysis/src/test/resources/testkit/testkit_cfg.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "This config contains additional fields used in pbsmrtpipe standalone tests",
+  "jobName": "test_job",
+  "workflowXml": null,
+  "entryPoints": [{
+    "entryId": "eid_subread",
+    "path": "/path/to/subreadset.xml"
+  }, {
+    "entryId": "eid_ref_dataset",
+    "path": "/path/to/referenceset.xml"
+  }],
+  "description": "simple test config",
+  "jobType": "pbsmrtpipe",
+  "presetXml": "preset.xml",
+  "reportTests": [{
+    "reportId": "example_report",
+    "rules": [{
+      "attrId": "mapped_reads_n",
+      "op": "gt",
+      "value": 100
+    }, {
+      "attrId": "concordance",
+      "op": "ge",
+      "value": 0.85
+    }, {
+      "attrId": "instrument",
+      "value": "54006"
+    }]
+  }],
+  "pipelineId": "pbsmrtpipe.pipelines.sa3_sat",
+  "output_dir": "job_output",
+  "py_tests": []
+}

--- a/smrt-server-analysis/src/test/scala/TestkitSpec.scala
+++ b/smrt-server-analysis/src/test/scala/TestkitSpec.scala
@@ -1,0 +1,41 @@
+
+import java.nio.file.Paths
+
+import org.specs2.mutable.Specification
+
+import spray.json._
+
+import com.pacbio.secondary.smrtserver.testkit._
+
+class TestkitSpec extends Specification with TestkitJsonProtocol {
+  import TestkitModels._
+
+
+  "Testkit config" should {
+    "Convert testkit config object to JSON" in {
+      val entryPoints = Seq(
+        EntryPointPath("eid_subread", Paths.get("/path/to/subreadset.xml")),
+        EntryPointPath("eid_ref_dataset", Paths.get("/path/to/referenceset.xml")))
+      val reportTests = Seq(ReportTestRules(
+        "example_report",
+        Seq(
+          ReportAttributeLongRule("mapped_reads_n", "gt", 100),
+          ReportAttributeDoubleRule("concordance", "ge", 0.85),
+          ReportAttributeStringRule("instrument", "54006"))))
+      val cfg = TestkitConfig(
+        "test_job",
+        "pbsmrtpipe",
+        "simple test config",
+        Some("pbsmrtpipe.pipelines.sa3_sat"),
+        None,
+        Some("preset.xml"),
+        None,
+        entryPoints,
+        reportTests)
+      val json = cfg.toJson
+      println(json.prettyPrint)
+      val cfg2 = json.convertTo[TestkitConfig]
+      true must beEqualTo(cfg.jobName == cfg2.jobName)
+    }
+  }
+}

--- a/smrt-server-analysis/src/test/scala/TestkitSpec.scala
+++ b/smrt-server-analysis/src/test/scala/TestkitSpec.scala
@@ -1,6 +1,8 @@
 
 import java.nio.file.Paths
 
+import scala.io.Source
+
 import org.specs2.mutable.Specification
 
 import spray.json._
@@ -10,6 +12,7 @@ import com.pacbio.secondary.smrtserver.testkit._
 class TestkitSpec extends Specification with TestkitJsonProtocol {
   import TestkitModels._
 
+  val test_cfg = "testkit/testkit_cfg.json"
 
   "Testkit config" should {
     "Convert testkit config object to JSON" in {
@@ -29,13 +32,17 @@ class TestkitSpec extends Specification with TestkitJsonProtocol {
         Some("pbsmrtpipe.pipelines.sa3_sat"),
         None,
         Some("preset.xml"),
-        None,
         entryPoints,
         reportTests)
       val json = cfg.toJson
       println(json.prettyPrint)
       val cfg2 = json.convertTo[TestkitConfig]
       true must beEqualTo(cfg.jobName == cfg2.jobName)
+      val jsonPath = Paths.get(getClass.getResource(test_cfg).toURI).toString
+      val jsonSrc = Source.fromFile(jsonPath).getLines.mkString
+      val jsonAst = jsonSrc.parseJson
+      val cfg3 = jsonAst.convertTo[TestkitConfig]
+      true must beEqualTo(cfg.jobName == cfg3.jobName)
     }
   }
 }


### PR DESCRIPTION
This is only the first step, but I'd like to get some quick feedback before using this.  Currently the JSON spec looks something like this:

```
{
  "jobName": "test_job",
  "workflowXml": null,
  "entryPoints": [{
    "entryId": "eid_subread",
    "path": "/path/to/subreadset.xml"
  }, {
    "entryId": "eid_ref_dataset",
    "path": "/path/to/referenceset.xml"
  }],
  "description": "simple test config",
  "jobType": "pbsmrtpipe",
  "outputDir": null,
  "presetXml": "preset.xml",
  "reportTests": [{
    "reportId": "example_report",
    "rules": [{
      "attrId": "mapped_reads_n",
      "op": "gt",
      "value": 100
    }, {
      "attrId": "concordance",
      "op": "ge",
      "value": 0.85
    }, {
      "attrId": "instrument",
      "value": "54006"
    }]
  }],
  "pipelineId": "pbsmrtpipe.pipelines.sa3_sat"
}
```

In the old testkit code, the report attribute rules are specified like this:

  "mapped_reads_n__gt": 100

I find this syntax easier to work with, and it's easily converted into the ReportAttributeRule objects, but I'm not sure how good an idea it is to have the JSON structure diverge from the underlying data model.  Do we care?