### PR TITLE
Slick + RDBMS timing

### DIFF
--- a/smrt-server-database/src/main/scala/com/pacbio/database/ProfilingListener.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/ProfilingListener.scala
@@ -1,12 +1,24 @@
 package com.pacbio.database
 
+import java.io._
+
+import scala.collection.mutable.ArrayBuffer
+
 /**
- * Created by jfalkner on 6/10/16.
+ * Collects and displays Slick Database use frequency and timing
+ *
+ * This listener takes com.pacbio.database.DatabaseListener events and uses them to track what line
+ * of scala code runs DB queries, how often and how long the queries take.
+ *
+ * See README.md for enabling this code and example output
+ *
+ *   https://github.com/PacificBiosciences/smrtflow/tree/master/smrt-server-database#debugging-and-profiling
  */
 class ProfilingListener extends DatabaseListener {
 
   var errors = Map[String, Int]()
-  var complete = Map[String, Int]()
+  var allDoneLog = Map[String, ArrayBuffer[Long]]()
+  var dbDoneLog = Map[String, ArrayBuffer[Long]]()
 
   // life cycle of the nested Future. useful for debugging nested db.run use
   override def create(code: String, stacktrace: Throwable): Unit = {}
@@ -16,27 +28,21 @@ class ProfilingListener extends DatabaseListener {
   override def timeout(
       code: String,
       stacktrace: Throwable,
-      t: Throwable): Unit = {
+      t: Throwable): Unit =
     errors += (code -> (errors.getOrElse(code, 0) + 1))
-    printSummary
-  }
 
   override def error(
       code: String,
       stacktrace: Throwable,
-      t: Throwable): Unit = {
+      t: Throwable): Unit =
     errors += (code -> (errors.getOrElse(code, 0) + 1))
-    printSummary
-  }
 
   override def allDone(
       start: Long,
       end: Long,
       code: String,
-      stacktrace: Throwable): Unit = {
-    complete += (code -> (complete.getOrElse(code, 0) + 1))
-    printSummary
-  }
+      stacktrace: Throwable): Unit =
+    allDoneLog += (code -> (allDoneLog.getOrElse(code, ArrayBuffer.empty[Long]) += (end - start)))
 
   override def success(
       code: String,
@@ -47,17 +53,66 @@ class ProfilingListener extends DatabaseListener {
       start: Long,
       end: Long,
       code: String,
-      stacktrace: Throwable): Unit = Unit
+      stacktrace: Throwable): Unit =
+    dbDoneLog += (code -> (dbDoneLog.getOrElse(code, ArrayBuffer.empty[Long]) += (end - start)))
 
-  def printSummary: Unit = {
-    val buf = new StringBuilder()
+  var latestBuffer = new StringWriter()
+  sys addShutdownHook{
+    // a dump to the logs
+    printSummary(new OutputStreamWriter(System.out))
+    // write out to some temp files
+    if (new File("/tmp").exists) {
+      // write out usage
+      val usage = new FileWriter("/tmp/PACBIO_DATABASE_usage.csv")
+      try showUsage(usage) finally usage.close()
+      // write out timing
+      val timing = new FileWriter("/tmp/PACBIO_DATABASE_timing.csv")
+      try showTiming(timing) finally timing.close()
+    }
+  }
+
+  // prints out the frequency of usage along with success and failure
+  // make a final row for all keys observed in errors and complete
+  def showUsage(buf : Writer = new StringWriter()): Unit = {
+    buf.append("Code,Success,Failures\n")
+    val rows = for (k <- List(errors.keySet ++ allDoneLog.keySet).flatten)
+      yield (k, allDoneLog.getOrElse(k, ArrayBuffer.empty[Long]), errors.getOrElse(k, 0))
+    // count entries in the lists
+    val sumRows = rows.map(x => (x._1, x._2.length, x._3))
+    // sort by most frequent and display
+    for ((k, success, fail) <- sumRows.sortWith(_._2 > _._2))
+      buf.append(s"$k, $success, $fail\n")
+    buf.flush()
+  }
+
+  // prints out total use and time spent by the queries
+  def showTiming(buf : Writer = new StringWriter()): Unit = {
+    buf.append("Code,Sum,Avg,Min,Max,Usage\n")
+    val rows = for (k <- dbDoneLog.keySet)
+      yield (
+          k,
+          dbDoneLog.getOrElse(k, ArrayBuffer.empty[Long]).sum,
+          dbDoneLog.getOrElse(k, ArrayBuffer.empty[Long]).sum)
+    def convert(k: String): (String, Long, Long, Long, Long, Int) = {
+      val times = dbDoneLog(k)
+      val sum = times.sum
+      val avg = sum / times.size
+      val min = times.reduceLeft(_ min _)
+      val max = times.reduceLeft(_ max _)
+      (k, sum, avg, min, max, times.size)
+    }
+    val rows2: Seq[(String, Long, Long, Long, Long, Int)] = List(dbDoneLog.keySet).flatten.map(k => convert(k))
+    // sort by most frequent and display
+    for ((k, sum, avg, min, max, freq) <- rows2.sortWith(_._2 > _._2))
+      buf.append(s"$k, $sum, $avg, $min, $max, $freq\n")
+    buf.flush()
+  }
+
+  def printSummary(buf : Writer = new StringWriter()): Unit = {
     buf.append("*** DB Use Summary ***\n")
-    buf.append("Code,Success, Failures\n")
-    val rows = for(k <- List(errors.keySet ++ complete.keySet).flatten)
-      yield (k, complete.getOrElse(k, 0), errors.getOrElse(k, 0))
-    for ((k, _, _) <- rows.sortWith(_._2 > _._2))
-      buf.append(s"$k, ${complete.getOrElse(k, 0)}, ${errors.getOrElse(k, 0)}\n")
-    println(buf)
+    showUsage(buf)
+    showTiming(buf)
+    buf.flush()
   }
 
 }


### PR DESCRIPTION
CC @skinner 

Fixes #149

Some improvements to the `ProfilingListener` so that approximate timing metrics exist for the time it takes Slick + RDBMS (SQLite currently) to execute a `DBIOAction`. [README.md](https://github.com/PacificBiosciences/smrtflow/blob/db_usage_timing/smrt-server-database/README.md#query-timing) updates have the example, but now upon JVM exit both usage and timing metrics are dumped.

```
# example DBIOAction timing, sorted by total time 
Code,Sum,Avg,Min,Max,Usage
c.p.s.s.a.DataSetStore$class.getSubreadDataSets(JobsDao.scala:713), 2157, 134, 108, 188, 16
c.p.s.s.a.JobDataStore$class.getJobsByTypeId(JobsDao.scala:382), 1350, 32, 0, 99, 42
c.p.s.s.a.DataSetStore$class.getAlignmentDataSets(JobsDao.scala:796), 1016, 101, 82, 131, 10
c.p.s.s.a.JobDataStore$class.getJobs(JobsDao.scala:379), 385, 128, 92, 191, 3
c.p.s.s.a.DataSetStore$class.getReferenceDataSets(JobsDao.scala:724), 295, 16, 14, 21, 18
c.p.s.s.a.JobDataStore$class.updateJobStateByUUID(JobsDao.scala:301), 202, 3, 2, 8, 60
c.p.s.s.a.DataSetStore$class.getHdfDataSets(JobsDao.scala:750), 106, 10, 9, 12, 10
c.p.s.s.a.JobDataStore$class.createJob(JobsDao.scala:366), 98, 6, 4, 22, 15
c.p.s.s.a.DataSetStore$class.addOptionalInsert$1(JobsDao.scala:535), 64, 1, 0, 3, 55
c.p.s.s.a.JobDataStore$class.getJobByUUID(JobsDao.scala:230), 46, 0, 0, 1, 70
c.p.s.s.a.JobDataStore$class.getJobById(JobsDao.scala:233), 42, 0, 0, 1, 74
c.p.s.s.d.DatabaseRunDao.updateOrCreate(DatabaseRunDao.scala:55), 39, 7, 5, 15, 5
c.p.s.s.a.DataSetStore$class.insertDataStoreByJob(JobsDao.scala:539), 29, 0, 0, 2, 55
c.p.s.s.a.DataSetStore$class.insertSubreadDataSet(JobsDao.scala:619), 26, 5, 3, 9, 5
c.p.s.s.a.DataSetStore$class.insertReferenceDataSet(JobsDao.scala:599), 23, 4, 4, 5, 5
c.p.s.s.a.DataSetStore$class.getDataSetByUUID(JobsDao.scala:677), 18, 0, 0, 2, 26
c.p.s.s.a.DataSetStore$class.getDataStoreFiles(JobsDao.scala:854), 10, 3, 2, 5, 3
c.p.s.s.a.DataSetStore$class.getReferenceDataSetById(JobsDao.scala:730), 4, 0, 0, 1, 5
c.p.s.s.a.DataSetStore$class.getDataSetMetaDataSet(JobsDao.scala:577), 4, 0, 0, 1, 10
```

```
# example usage sorted by frequency
Code,Success,Failures
c.p.s.s.a.JobDataStore$class.getJobById(JobsDao.scala:233), 74, 0
c.p.s.s.a.JobDataStore$class.getJobByUUID(JobsDao.scala:230), 70, 0
c.p.s.s.a.JobDataStore$class.updateJobStateByUUID(JobsDao.scala:301), 60, 0
c.p.s.s.a.DataSetStore$class.insertDataStoreByJob(JobsDao.scala:539), 55, 0
c.p.s.s.a.DataSetStore$class.addOptionalInsert$1(JobsDao.scala:535), 55, 0
c.p.s.s.a.JobDataStore$class.getJobsByTypeId(JobsDao.scala:382), 42, 0
c.p.s.s.a.DataSetStore$class.getDataSetByUUID(JobsDao.scala:677), 26, 0
c.p.s.s.a.DataSetStore$class.getReferenceDataSets(JobsDao.scala:724), 18, 0
c.p.s.s.a.DataSetStore$class.getSubreadDataSets(JobsDao.scala:713), 16, 0
c.p.s.s.a.JobDataStore$class.createJob(JobsDao.scala:366), 15, 0
c.p.s.s.a.DataSetStore$class.getAlignmentDataSets(JobsDao.scala:796), 10, 0
c.p.s.s.a.DataSetStore$class.getHdfDataSets(JobsDao.scala:750), 10, 0
c.p.s.s.a.DataSetStore$class.getDataSetMetaDataSet(JobsDao.scala:577), 10, 0
c.p.s.s.a.DataSetStore$class.insertSubreadDataSet(JobsDao.scala:619), 5, 0
com.pacbio.secondary.smrtlink.database.DatabaseRunDao.updateOrCreate(DatabaseRunDao.scala:55), 5, 0
c.p.s.s.a.DataSetStore$class.getReferenceDataSetById(JobsDao.scala:730), 5, 0
c.p.s.s.a.DataSetStore$class.insertReferenceDataSet(JobsDao.scala:599), 5, 0
c.p.s.s.a.JobDataStore$class.getJobs(JobsDao.scala:379), 3, 0
c.p.s.s.a.DataSetStore$class.getDataStoreFiles(JobsDao.scala:854), 3, 0
```

If you want to reproduce the above, turn on set the `-DPACBIO_DATABASE=profiling` flag as noted in the readme, use `--log-level DEBUG` and do the following.

```
# clean db, load mock data, then start the server
rm -fr smrt-server-analysis/db
sbt "smrt-server-link/run-main com.pacbio.secondary.smrtlink.tools.InsertMockData"
make start-smrt-server-analysis > server_out.txt 2> server_err.txt

# (diff terminal) run stress.py
./stress.py 2> stress_err.txt > stress_out.txt
# when complete, kill the server with Ctrl + C
```

