### PR TITLE
Eager Flyway migrations

### DIFF
--- a/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
@@ -109,6 +109,8 @@ class Database(dbURI: String) {
   flyway.setDataSource(connectionPool)
   flyway.setBaselineOnMigrate(true)
   flyway.setBaselineVersionAsString("1")
+  // eagerly run migrations
+  migrate()
 
   // keep access to the real database restricted. we don't want atyptical use in the codebase
   // TODO: -1 queueSize means unlimited. This probably needs to be tuned


### PR DESCRIPTION
CC @skinner 

Runs Flyway migrations in an eager fashion but otherwise keeps the same guard in place to make sure migrations have run before other `db.run` use occurs.

This is a followup to a discussion on Slack where @skinner noted that some timeouts were being observed while running `stress.py` because the first few `db.run` usages blocked on relative long-running migrations.