### PR TITLE
Dataset report fixes

### DIFF
--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/constants/FileTypes.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/constants/FileTypes.scala
@@ -122,6 +122,9 @@ object FileTypes {
   // fasta.contig.index index file used by SMRT View
   final val I_FCI = IndexFileBaseType("PacBio.Index.FastaContigIndex", "file", "fasta.contig.index", "text/plain")
 
+  // Other DataSet accessories
+  final val STS_XML = FileBaseType("PacBio.SubreadFile.ChipStatsFile", "file", "sts.xml", "application/xml")
+
   // Only Supported RS era Reference Index file types, which are used to
   // convert to ReferenceSet
   final val RS_I_SAM_INDEX = IndexFileBaseType("sam_idx", "file", "fasta.fai", "text/plain")

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/externaltools/PbReports.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/externaltools/PbReports.scala
@@ -31,7 +31,7 @@ trait CallPbReport extends Python {
     }
   }
 
-  def canProcess(dst: DataSetMetaTypes.DataSetMetaType): Boolean
+  def canProcess(dst: DataSetMetaTypes.DataSetMetaType, hasStatsXml: Boolean = false): Boolean
 }
 
 object PbReports {
@@ -42,24 +42,24 @@ object PbReports {
   object FilterStatsXml extends CallPbReport {
     val reportModule = "filter_stats_xml"
     val reportTaskId = "pbreports.tasks.filter_stats_report_xml"
-    def canProcess(dst: DataSetMetaTypes.DataSetMetaType) = {
-      dst == DataSetMetaTypes.Subread
+    def canProcess(dst: DataSetMetaTypes.DataSetMetaType, hasStatsXml: Boolean) = {
+      (dst == DataSetMetaTypes.Subread) && (hasStatsXml)
     }
   }
 
   object LoadingXml extends CallPbReport {
     val reportModule = "loading_xml"
     val reportTaskId = "pbreports.tasks.loading_report_xml"
-    def canProcess(dst: DataSetMetaTypes.DataSetMetaType) = {
-      dst == DataSetMetaTypes.Subread
+    def canProcess(dst: DataSetMetaTypes.DataSetMetaType, hasStatsXml: Boolean) = {
+      (dst == DataSetMetaTypes.Subread) && (hasStatsXml)
     }
   }
 
   object AdapterXml extends CallPbReport {
     val reportModule = "adapter_xml"
     val reportTaskId = "pbreports.tasks.adapter_report_xml"
-    def canProcess(dst: DataSetMetaTypes.DataSetMetaType) = {
-      dst == DataSetMetaTypes.Subread
+    def canProcess(dst: DataSetMetaTypes.DataSetMetaType, hasStatsXml: Boolean) = {
+      (dst == DataSetMetaTypes.Subread) && (hasStatsXml)
     }
   }
 

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/externaltools/PbReports.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/externaltools/PbReports.scala
@@ -7,8 +7,12 @@ import java.nio.file.Path
 /**
  * External Call To pbreports
  */
+
+case class PbReport(outputJson: Path, taskId: String)
+
 trait CallPbReport extends Python {
   val reportModule: String
+  val reportTaskId: String
 
   def apply(stsXml: Path, outputJson: Path): Option[ExternalCmdFailure] = {
     val cmd = Seq(
@@ -20,10 +24,10 @@ trait CallPbReport extends Python {
     runSimpleCmd(cmd)
   }
 
-  def run(stsXml: Path, outputJson: Path): Either[ExternalCmdFailure, Path] = {
+  def run(stsXml: Path, outputJson: Path): Either[ExternalCmdFailure, PbReport] = {
     apply(stsXml, outputJson) match {
       case Some(e) => Left(e)
-      case _ => Right(outputJson)
+      case _ => Right(PbReport(outputJson, reportTaskId))
     }
   }
 
@@ -37,6 +41,7 @@ object PbReports {
 
   object FilterStatsXml extends CallPbReport {
     val reportModule = "filter_stats_xml"
+    val reportTaskId = "pbreports.tasks.filter_stats_report_xml"
     def canProcess(dst: DataSetMetaTypes.DataSetMetaType) = {
       dst == DataSetMetaTypes.Subread
     }
@@ -44,6 +49,7 @@ object PbReports {
 
   object LoadingXml extends CallPbReport {
     val reportModule = "loading_xml"
+    val reportTaskId = "pbreports.tasks.loading_report_xml"
     def canProcess(dst: DataSetMetaTypes.DataSetMetaType) = {
       dst == DataSetMetaTypes.Subread
     }
@@ -51,6 +57,7 @@ object PbReports {
 
   object AdapterXml extends CallPbReport {
     val reportModule = "adapter_xml"
+    val reportTaskId = "pbreports.tasks.adapter_report_xml"
     def canProcess(dst: DataSetMetaTypes.DataSetMetaType) = {
       dst == DataSetMetaTypes.Subread
     }

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/reports/DataSetReports.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/reports/DataSetReports.scala
@@ -142,6 +142,6 @@ object DataSetReports {
 
     val reportPath = jobPath.resolve(simple + ".json")
     MockReportUtils.writeReport(rpt, reportPath)
-    toReportFile(reportPath, s"pbscala::${jobTypeId}")
+    toReportFile(reportPath, s"pbscala::${jobTypeId.id}")
   }
 }


### PR DESCRIPTION
It's gross but it works.  Here's how I test it using PacBioTestData after calling `sbt smrt-server-analysis/run`:

```
./smrt-server-analysis/target/pack/bin/pbservice import-dataset --host localhost --port 8070 `pbdata get subreads-sequel`
./smrt-server-analysis/target/pack/bin/pbservice import-dataset --host localhost --port 8070 `pbdata get subreads-xml`
```

The first SubreadSet includes an sts.xml and has pbreports reports run, the second does not.  I can easily turn this into an automated test using the new pbtestkit-service-runner - not sure where this should live though.