### PR TITLE
disable system job summary tick

### DIFF
--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/actors/EngineManagerActor.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/engine/actors/EngineManagerActor.scala
@@ -63,9 +63,6 @@ class EngineManagerActor(val daoActor: ActorRef,
 
   val checkForWorkTick = context.system.scheduler.schedule(10.seconds, checkForWorkInterval, self, CheckForRunnableJob)
 
-  // Log the job summary. This should probably be in a health agent
-  val tick = context.system.scheduler.schedule(10.seconds, logStatusInterval, daoActor, GetSystemJobSummary)
-
   // Keep track of workers
   val workers = mutable.Queue[ActorRef]()
 
@@ -90,7 +87,6 @@ class EngineManagerActor(val daoActor: ActorRef,
   }
 
   override def postStop(): Unit = {
-    tick.cancel()
     checkForWorkTick.cancel()
   }
 

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDaoActor.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDaoActor.scala
@@ -209,9 +209,6 @@ class JobsDaoActor(dao: JobsDao, val engineConfig: EngineConfig, val resolver: J
 
   val checkForWorkTick = context.system.scheduler.schedule(10.seconds, checkForWorkInterval, self, CheckForRunnableJob)
 
-  // Log the job summary. This should probably be in a health agent
-  val tick = context.system.scheduler.schedule(10.seconds, logStatusInterval, self, GetSystemJobSummary)
-
   // Keep track of workers
   val workers = mutable.Queue[ActorRef]()
 


### PR DESCRIPTION
Before this change, I was seeing 12 to 50 of `Ask timed out` errors when I ran `pbtestkit-service-multirunner service-test-tiny-jobs.txt` with a copy of the smrtlink-beta database (on NFS).

With this change, I see two `Ask timed out` errors (I've run one complete test run so far).

The periodic GetSystemJobSummary tick would query for all the engine jobs and all the datastore files (two of the larger tables in our DB).  If a separate query was queued behind those queries, it could run into the ask timeout.

AFAIK most developers are working on an SSD and/or with a small database, and you wouldn't hit those timeouts in that case.

We should increase the timeouts as well; I'll make a separate PR for that.