### PR TITLE
Remove commit() cleanup

### DIFF
--- a/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
@@ -217,7 +217,6 @@ class Database(dbURI: String) {
           val conn = connectionPool.cachedConnection
           if (!conn.isClosed)
             try {
-              conn.commit()
               conn.close()
             } catch {
               case ex: Throwable => println("Ignoring commit()/close() fail: " + ex)


### PR DESCRIPTION
Quick fix to incorrect `commit()` use. This should have previously always failed with the exception logged then ignored.

The [JavaDocs note](https://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#commit())

> Makes all changes made since the previous commit/rollback permanent and releases any database locks currently held by this Connection object. This method should be used only when auto-commit mode has been disabled.

So the old cleanup wasn't helpful. In the case of auto-commit (default, I think) this wouldn't work. In the case of no auto-commit, the transaction was not manually committed for some reason. It is unclear if it is correct to assume it should be committed.