### PR TITLE
Switch sample service to use DB

### DIFF
--- a/smrt-common-models/src/main/java/com/pacificbiosciences/pacbiorightsandroles/RnR.java
+++ b/smrt-common-models/src/main/java/com/pacificbiosciences/pacbiorightsandroles/RnR.java
@@ -144,7 +144,7 @@ public class RnR {
     /**
      * A project is of type AccessRight and can be defined the same way, defined by a URI (ResoureId attribute) and access controlled by using the AccessDisabled attribute, set to 'false' to grant users access.
      * 
-     * A user (with a role, which has access rights) has one more projects with which they’re associated.  Via this association, one or more users may own a project, and one or more users may be granted access to a project, simply by being associated with it.
+     * A user (with a role, which has access rights) has one more projects with which they are associated.  Via this association, one or more users may own a project, and one or more users may be granted access to a project, simply by being associated with it.
      * 
      * @return
      *     possible object is

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/app/SmrtLinkApp.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/app/SmrtLinkApp.scala
@@ -2,14 +2,14 @@ package com.pacbio.secondary.smrtlink.app
 
 import java.nio.file.{Files, Paths}
 
-import com.pacbio.common.app.{BaseApi, BaseServer, AuthenticatedCoreProviders}
+import com.pacbio.common.app.{AuthenticatedCoreProviders, BaseApi, BaseServer}
 import com.pacbio.common.dependency.Singleton
 import com.pacbio.secondary.analysis.configloaders.PbsmrtpipeConfigLoader
 import com.pacbio.secondary.smrtlink.actors._
 import com.pacbio.secondary.smrtlink.auth.SmrtLinkRolesInit
-import com.pacbio.secondary.smrtlink.database.DatabaseRunDaoProvider
+import com.pacbio.secondary.smrtlink.database.{DatabaseRunDaoProvider, DatabaseSampleDaoProvider}
 import com.pacbio.secondary.smrtlink.models.DataModelParserImplProvider
-import com.pacbio.secondary.smrtlink.services.jobtypes.{MockPbsmrtpipeJobTypeProvider, MergeDataSetServiceJobTypeProvider, ImportDataSetServiceTypeProvider}
+import com.pacbio.secondary.smrtlink.services.jobtypes.{ImportDataSetServiceTypeProvider, MergeDataSetServiceJobTypeProvider, MockPbsmrtpipeJobTypeProvider}
 import com.pacbio.secondary.smrtlink.services._
 import com.pacbio.logging.LoggerOptions
 import com.typesafe.scalalogging.LazyLogging
@@ -37,7 +37,7 @@ trait SmrtLinkProviders extends
   SampleServiceActorRefProvider with
   RegistryServiceActorRefProvider with
   DatabaseRunDaoProvider with
-  InMemorySampleDaoProvider with
+  DatabaseSampleDaoProvider with
   ImportDataSetServiceTypeProvider with
   MergeDataSetServiceJobTypeProvider with
   MockPbsmrtpipeJobTypeProvider with

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/database/DatabaseSampleDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/database/DatabaseSampleDao.scala
@@ -2,10 +2,11 @@ package com.pacbio.secondary.smrtlink.database
 
 import java.util.UUID
 
+import com.pacbio.common.dependency.Singleton
 import com.pacbio.common.services.PacBioServiceErrors.{ResourceNotFoundError, UnprocessableEntityError}
-import com.pacbio.common.time.Clock
+import com.pacbio.common.time.{Clock, ClockProvider}
 import com.pacbio.database.Database
-import com.pacbio.secondary.smrtlink.actors.SampleDao
+import com.pacbio.secondary.smrtlink.actors.{DalProvider, SampleDao, SampleDaoProvider}
 import com.pacbio.secondary.smrtlink.database.TableModels._
 import com.pacbio.secondary.smrtlink.models._
 
@@ -90,4 +91,18 @@ class DatabaseSampleDao(db: Database, clock: Clock) extends SampleDao {
 
     db.run(action)
   }
+}
+
+/**
+  * Provides a DatabaseRunDao.
+  */
+trait DatabaseSampleDaoProvider extends SampleDaoProvider
+  with ClockProvider {
+  this: DalProvider with DataModelParserProvider =>
+
+  //
+  //this: DalProvider with DataModelParserProvider =>
+
+  override final val sampleDao: Singleton[SampleDao] =
+    Singleton(() => new DatabaseSampleDao(db(), clock()))
 }


### PR DESCRIPTION
The routes were using an InMemoryDao like the unit tests; this change is to switch to the DB instead. For bugzilla 31624. Also a change to remove a curly unicode quote from a comment which tripped up my build on Mac.