### PR TITLE
Don't discard eclipse API. Needed for subreadset.xml parsing

### DIFF
--- a/smrt-server-lims/build.sbt
+++ b/smrt-server-lims/build.sbt
@@ -7,8 +7,8 @@ mainClass in assembly := Some("com.pacbio.secondary.lims.MainSimple")
 
 assemblyMergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) => {
   case PathList("application.conf") => MergeStrategy.first
-  case PathList("org", "slf4j", xs @ _*) => MergeStrategy.first
-  case PathList("org", "eclipse", xs @ _*) => MergeStrategy.discard
+  case PathList("org", "slf4j", xs@_*) => MergeStrategy.first
+  case PathList("org", "eclipse", xs@_*) => MergeStrategy.first
   case p if p.endsWith("eclipse.inf") => MergeStrategy.discard
   case "logback.xml" => MergeStrategy.first
   case x => old(x)


### PR DESCRIPTION
Enables the current `smrt-lims` server to import subreadset.xml files. After switching to use assembly, the eclipse persistence API was dropped, which caused errors when parsing XML. It now works. Tested manually.