### PR TITLE
Fixed --log-file flag

### DIFF
--- a/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
+++ b/smrt-server-logging/src/main/scala/com/pacbio/logging/LoggerOptions.scala
@@ -66,7 +66,7 @@ object LoggerOptions {
   }
 
   def parseAddDebug(args: Seq[String]): Unit = {
-    val requireOne = Set("--logfile", "--log2stdout", "-h")
+    val requireOne = Set("--log-file", "--log2stdout", "-h")
     val v = if (args.filter(requireOne).isEmpty) args :+ "--log2stdout" else args
     parse(v)
   }


### PR DESCRIPTION
CC @skinner @mpkocher 

Fixed use of the `--log-file` flag. What happened is that a helper method that would auto-set `--debug` if no file or debug was set got out of sync with a change that did `s/--logfile/--log-file`.

Probably should have been covered by a test. Can file a ticket for that if desired later. This should fix it.

```
$ sbt "smrt-server-analysis/run --log-file /tmp/foo.log"
...
cat /tmp/foo.log

# notice, sbt uses the relative path as the sub-project
$ sbt "smrt-server-analysis/run --log-file foo.log"
...
cat smrt-server-analysis/foo.log
```