### PR TITLE
Project api changes

### DIFF
--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -62,50 +62,82 @@ trait DalComponent {
 trait ProjectDataStore extends LazyLogging {
   this: DalComponent with SmrtLinkConstants =>
 
-  def getProjects(limit: Int = 100): Future[Seq[Project]] = db.run(projects.take(limit).result)
+  def getProjects(limit: Int = 100): Future[Seq[Project]] =
+    db.run(projects.take(limit).result)
 
   def getProjectById(projId: Int): Future[Option[Project]] =
     db.run(projects.filter(_.id === projId).result.headOption)
 
-  def createProject(opts: ProjectRequest): Future[Project] = {
+  def createProject(projReq: ProjectRequest, ownerLogin: String): Future[Project] = {
+    val owner = ProjectRequestUser(RequestUser(ownerLogin), "Owner")
+    val usersWithOwner = projReq.members.filter(_.user.login != ownerLogin) ++ List(owner)
+    val requestWithOwner = projReq.copy(members = usersWithOwner)
+
     val now = JodaDateTime.now()
-    val proj = Project(-99, opts.name, opts.description, "CREATED", now, now)
-    val action = projects returning projects.map(_.id) into((p, i) => p.copy(id = i)) += proj
-    db.run(action)
+    val proj = Project(-99, projReq.name, projReq.description, "CREATED", now, now)
+    val insert = projects returning projects.map(_.id) into((p, i) => p.copy(id = i)) += proj
+    val fullAction = insert.flatMap(proj => setMembersAndDatasets(proj, requestWithOwner))
+    db.run(fullAction.transactionally)
   }
 
-  def updateProject(projId: Int, opts: ProjectRequest): Future[Option[Project]] = {
+  def setMembersAndDatasets(proj: Project, projReq: ProjectRequest): DBIO[Project] =
+    DBIO.seq(
+      setProjectMembers(proj.id, projReq.members),
+      setProjectDatasets(proj.id, projReq.datasets)
+    ).andThen(DBIO.successful(proj))
+
+  def setProjectMembers(projId: Int, members: Seq[ProjectRequestUser]): DBIO[Unit] =
+    DBIO.seq(
+      projectsUsers.filter(_.projectId === projId).delete,
+      projectsUsers ++= members.map(m => ProjectUser(projId, m.user.login, m.role))
+    )
+
+  def setProjectDatasets(projId: Int, ids: Seq[RequestId]): DBIO[Unit] = {
     val now = JodaDateTime.now()
-    val update = projects
-      .filter(_.id === projId)
-      .map(p => (p.name, p.state, p.description, p.updatedAt))
-      .update(opts.name, opts.state, opts.description, now)
+    DBIO.seq(
+      // move datasets not in the list of ids back to the general project
+      dsMetaData2
+        .filter(_.projectId === projId)
+        .filterNot(_.id inSet ids.map(_.id))
+        .map(ds => (ds.projectId, ds.updatedAt))
+        .update((GENERAL_PROJECT_ID, now)),
+      // move datasets that *are* in the list of IDs into this project
+      dsMetaData2
+        .filter(_.id inSet ids.map(_.id))
+        .map(ds => (ds.projectId, ds.updatedAt))
+        .update((projId, now))
+    )
+  }
 
-    val updateAndGet = update >> projects.filter(_.id === projId).result.headOption
+  def updateProject(projId: Int, projReq: ProjectRequest): Future[Option[Project]] = {
+    val now = JodaDateTime.now()
+    val update = projReq.state match {
+      case Some(state) =>
+        projects
+          .filter(_.id === projId)
+          .map(p => (p.name, p.state, p.description, p.updatedAt))
+          .update((projReq.name, state, projReq.description, now))
+      case None =>
+        projects
+          .filter(_.id === projId)
+          .map(p => (p.name, p.description, p.updatedAt))
+          .update((projReq.name, projReq.description, now))
+    }
 
-    db.run(updateAndGet)
+    val fullAction = update.andThen(
+      projects.filter(_.id === projId).result.headOption.flatMap { maybeProj =>
+        maybeProj match {
+          case Some(proj) => setMembersAndDatasets(proj, projReq).map(Some(_))
+          case None => DBIO.successful(None)
+        }
+      }
+    )
+
+    db.run(fullAction.transactionally)
   }
 
   def getProjectUsers(projId: Int): Future[Seq[ProjectUser]] =
     db.run(projectsUsers.filter(_.projectId === projId).result)
-
-  def addProjectUser(projId: Int, user: ProjectUserRequest): Future[MessageResponse] = {
-    val action = DBIO.seq(
-      projectsUsers.filter(x => x.projectId === projId && x.login === user.login).delete,
-      projectsUsers += ProjectUser(projId, user.login, user.role)
-    ).map(_ => MessageResponse(s"added user ${user.login} with role ${user.role} to project $projId")).transactionally
-
-    db.run(action)
-  }
-
-  def deleteProjectUser(projId: Int, user: String): Future[MessageResponse] = {
-    val action = projectsUsers
-      .filter(x => x.projectId === projId && x.login === user)
-      .delete
-      .map(_ => MessageResponse(s"removed user $user from project $projId"))
-
-    db.run(action)
-  }
 
   def getDatasetsByProject(projId: Int): Future[Seq[DataSetMetaDataSet]] =
     db.run(dsMetaData2.filter(_.projectId === projId).result)
@@ -150,28 +182,6 @@ trait ProjectDataStore extends LazyLogging {
       .map(_.map(j => ProjectDatasetResponse(j._1, j._2, None)))
 
     db.run(userProjects.zip(genProjects).map(p => p._1 ++ p._2))
-  }
-
-  def setProjectForDatasetId(dsId: Int, projId: Int): Future[MessageResponse] = {
-    val now = JodaDateTime.now()
-    val action = dsMetaData2
-      .filter(_.id === dsId)
-      .map(ds => (ds.projectId, ds.updatedAt))
-      .update(projId, now)
-      .map(_ => MessageResponse(s"moved dataset with ID $dsId to project $projId"))
-
-    db.run(action)
-  }
-
-  def setProjectForDatasetUuid(dsId: UUID, projId: Int): Future[MessageResponse] = {
-    val now = JodaDateTime.now()
-    val action = dsMetaData2
-      .filter(_.uuid === dsId)
-      .map(ds => (ds.projectId, ds.updatedAt))
-      .update(projId, now)
-      .map(_ => MessageResponse(s"moved dataset with ID $dsId to project $projId"))
-
-    db.run(action)
   }
 }
 

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDaoActor.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDaoActor.scala
@@ -19,7 +19,7 @@ import com.pacbio.secondary.analysis.jobs.AnalysisJobStates.Completed
 import com.pacbio.secondary.analysis.jobs.JobModels.{DataStoreJobFile, PacBioDataStore, _}
 import com.pacbio.secondary.analysis.jobs._
 import com.pacbio.secondary.smrtlink.app.SmrtLinkConfigProvider
-import com.pacbio.secondary.smrtlink.models.{Converters, EngineJobEntryPointRecord, ProjectRequest, ProjectUserRequest, ReferenceServiceDataSet, GmapReferenceServiceDataSet}
+import com.pacbio.secondary.smrtlink.models.{Converters, EngineJobEntryPointRecord, ProjectRequest, ReferenceServiceDataSet, GmapReferenceServiceDataSet}
 import org.joda.time.{DateTime => JodaDateTime}
 
 import scala.collection.mutable

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/Models.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/Models.scala
@@ -502,19 +502,61 @@ case class GmapReferenceServiceDataSet(
 // Options used for Merging Datasets
 case class DataSetMergeServiceOptions(datasetType: String, ids: Seq[Int], name: String)
 
+// Project models
+
+// We have a simpler (cheaper to query) project case class for the API
+// response that lists many projects,
 case class Project(
     id: Int,
     name: String,
     description: String,
     state: String,
     createdAt: JodaDateTime,
-    updatedAt: JodaDateTime)
+    updatedAt: JodaDateTime) {
+
+  def makeFull(datasets: Seq[DataSetMetaDataSet], members: Seq[ProjectUserResponse]): FullProject =
+    FullProject(
+      id,
+      name,
+      description,
+      state,
+      createdAt,
+      updatedAt,
+      datasets,
+      members)
+}
+
+// and a more detailed case class for the API responses involving
+// individual projects.
+case class FullProject(
+    id: Int,
+    name: String,
+    description: String,
+    state: String,
+    createdAt: JodaDateTime,
+    updatedAt: JodaDateTime,
+    datasets: Seq[DataSetMetaDataSet],
+    members: Seq[ProjectUserResponse])
+
+// the json structures required in client requests are a subset of the
+// FullProject structure
+case class ProjectRequest(
+    id: Option[Int],
+    name: String,
+    description: String,
+    state: Option[String],
+    datasets: Seq[RequestId],
+    members: Seq[ProjectRequestUser])
+
+case class RequestId(id: Int)
+case class RequestUser(login: String)
+case class ProjectRequestUser(user: RequestUser, role:String)
 
 case class ProjectUser(projectId: Int, login: String, role: String)
 
-case class ProjectRequest(name: String, state: String, description: String)
+//case class ProjectRequest(name: String, state: String, description: String)
 
-case class ProjectUserRequest(login: String, role: String)
+//case class ProjectUserRequest(login: String, role: String)
 case class ProjectUserResponse(user: UserResponse, role: String)
 
 case class UserProjectResponse(role: Option[String], project: Project)

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/Models.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/Models.scala
@@ -539,14 +539,16 @@ case class FullProject(
     members: Seq[ProjectUserResponse])
 
 // the json structures required in client requests are a subset of the
-// FullProject structure
+// FullProject structure (the FullProject is a valid request, but many
+// fields are optional in requests).
 case class ProjectRequest(
-    id: Option[Int],
     name: String,
     description: String,
+    // if any of these are None in a PUT request, the corresponding
+    // value will stay the same (i.e., the update will be skipped).
     state: Option[String],
-    datasets: Seq[RequestId],
-    members: Seq[ProjectRequestUser])
+    datasets: Option[Seq[RequestId]],
+    members: Option[Seq[ProjectRequestUser]])
 
 case class RequestId(id: Int)
 case class RequestUser(login: String)
@@ -554,9 +556,6 @@ case class ProjectRequestUser(user: RequestUser, role:String)
 
 case class ProjectUser(projectId: Int, login: String, role: String)
 
-//case class ProjectRequest(name: String, state: String, description: String)
-
-//case class ProjectUserRequest(login: String, role: String)
 case class ProjectUserResponse(user: UserResponse, role: String)
 
 case class UserProjectResponse(role: Option[String], project: Project)

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/SmrtLinkJsonProtocols.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/SmrtLinkJsonProtocols.scala
@@ -167,8 +167,9 @@ trait SmrtLinkJsonProtocols
   implicit val mergeDataSetOptionFormat = jsonFormat3(MergeDataSetOptions)
 
   implicit val projectFormat: RootJsonFormat[Project] = cachedImplicit
+  implicit val fullProjectFormat: RootJsonFormat[FullProject] = cachedImplicit
   implicit val projectRequestFormat: RootJsonFormat[ProjectRequest] = cachedImplicit
-  implicit val projectUserRequestFormat: RootJsonFormat[ProjectUserRequest] = cachedImplicit
+  implicit val projectUserRequestFormat: RootJsonFormat[ProjectRequestUser] = cachedImplicit
   implicit val projectUserResponseFormat: RootJsonFormat[ProjectUserResponse] = cachedImplicit
 }
 

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/tools/SetupMockData.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/tools/SetupMockData.scala
@@ -245,10 +245,10 @@ trait MockUtils extends LazyLogging{
   }
 
   def insertMockProject(): Future[Unit] = {
-    val projectId = 1
+    val projectId = 2
     dao.db.run(
       DBIO.seq(
-        projects += Project(projectId, "Project 1", "Project 1 description", "CREATED", JodaDateTime.now(), JodaDateTime.now()),
+        projects += Project(projectId, "Project 2", "Project 2 description", "CREATED", JodaDateTime.now(), JodaDateTime.now()),
         projectsUsers += ProjectUser(projectId, "mkocher", "OWNER")
       )
     )


### PR DESCRIPTION
The original API had separate endpoints for changing the lists of users and datasets in a project.  But dbarreto objected on the grounds that the project page had one save button, and if multiple requests were required to save a project, it was awkward on the client to track the success/failure of partial project saves.  So this change makes it so that saving a project is a single request with a body that contains the project member/dataset lists.