### PR TITLE
custom JSON handling for EngineJob model

### DIFF
--- a/smrt-analysis/src/test/resources/misc-models/engine_job_unversioned.json
+++ b/smrt-analysis/src/test/resources/misc-models/engine_job_unversioned.json
@@ -1,0 +1,13 @@
+{
+  "name": "Job import-dataset",
+  "updatedAt": "2016-08-04T23:46:10.759Z",
+  "path": "/Users/mkocher/gh_mk_projects/smrtflow/smrt-server-analysis/jobs-root/000/000001",
+  "state": "SUCCESSFUL",
+  "uuid": "e4831a60-8833-4299-9732-d0c18277df32",
+  "jobTypeId": "import-dataset",
+  "id": 1,
+  "comment": "Importing DataSet",
+  "createdAt": "2016-08-04T23:46:04.768Z",
+  "createdBy": null,
+  "jsonSettings": "{\"path\":\"/Users/mkocher/gh_mk_projects/smrtflow/test-data/smrtserver-testdata/ds-references/mk-01/mk_name_01/referenceset.xml\",\"datasetType\":\"PacBio.DataSet.ReferenceSet\"}"
+}

--- a/smrt-analysis/src/test/resources/misc-models/engine_job_versioned.json
+++ b/smrt-analysis/src/test/resources/misc-models/engine_job_versioned.json
@@ -1,0 +1,15 @@
+{
+  "name": "Job import-dataset",
+  "updatedAt": "2016-08-04T23:46:10.759Z",
+  "path": "/Users/mkocher/gh_mk_projects/smrtflow/smrt-server-analysis/jobs-root/000/000001",
+  "state": "SUCCESSFUL",
+  "uuid": "e4831a60-8833-4299-9732-d0c18277df32",
+  "smrtlinkToolsVersion": "3.0.0",
+  "jobTypeId": "import-dataset",
+  "id": 1,
+  "smrtlinkVersion": "3.2.0",
+  "comment": "Importing DataSet",
+  "createdAt": "2016-08-04T23:46:04.768Z",
+  "createdBy": "root",
+  "jsonSettings": "{\"path\":\"/Users/mkocher/gh_mk_projects/smrtflow/test-data/smrtserver-testdata/ds-references/mk-01/mk_name_01/referenceset.xml\",\"datasetType\":\"PacBio.DataSet.ReferenceSet\"}"
+}

--- a/smrt-analysis/src/test/scala/EngineJobSpec.scala
+++ b/smrt-analysis/src/test/scala/EngineJobSpec.scala
@@ -1,0 +1,39 @@
+
+// FIXME we want to drop this as quickly as possible
+
+import java.nio.file.Paths
+import java.util.UUID
+
+import com.pacbio.secondary.analysis.jobs._
+import com.typesafe.scalalogging.LazyLogging
+import org.specs2.mutable._
+import spray.json._
+import scala.io.Source
+
+
+/* Test for EngineJob model serialization with backwards compatibility */
+class EngineJobSpec extends Specification with EngineJobJsonProtocol with LazyLogging {
+  import JobModels._
+
+  final val VERSIONED = "misc-models/engine_job_versioned.json"
+  final val UNVERSIONED = "misc-models/engine_job_unversioned.json"
+
+  sequential
+
+  "Testing EngineJob serialization" should {
+    "Read in complete JSON matching current model" in {
+      val path = Paths.get(getClass.getResource(VERSIONED).toURI)
+      val json = Source.fromFile(path.toFile).getLines.mkString.parseJson
+      val job = json.convertTo[EngineJob]
+      job.state must beEqualTo(AnalysisJobStates.SUCCESSFUL)
+      job.smrtlinkVersion must beEqualTo(Some("3.2.0"))
+    }
+    "Read in JSON generated from older model" in {
+      val path = Paths.get(getClass.getResource(UNVERSIONED).toURI)
+      val json = Source.fromFile(path.toFile).getLines.mkString.parseJson
+      val job = json.convertTo[EngineJob]
+      job.state must beEqualTo(AnalysisJobStates.SUCCESSFUL)
+      job.smrtlinkVersion must beEqualTo(None)
+    }
+  }
+}


### PR DESCRIPTION
I double-checked - 'pbservice' works with the current server code and with smrtlink-nightly (which is still running 3.1).