### PR TITLE
Api manager fixes

### DIFF
--- a/extras/wso2/smrtlink_swagger.json
+++ b/extras/wso2/smrtlink_swagger.json
@@ -1014,7 +1014,7 @@
     },
     "/secondary-analysis/datastore-files/{uuid}/download": {
       "get": {
-        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-auth-type": "None",
         "x-scope": "data-management",
         "x-throttling-tier": "Unlimited",
         "parameters": [

--- a/extras/wso2/smrtlink_swagger.json
+++ b/extras/wso2/smrtlink_swagger.json
@@ -31,8 +31,8 @@
           "description": "Data%20Management%20Authorization"
         },
         {
-          "name": "smrt-analysis",
-          "key": "smrt-analysis",
+          "name": "analysis",
+          "key": "analysis",
           "roles": "Internal%2FPbAdmin%2CInternal%2FPbLabTech%2CInternal%2FPbBioinformatician",
           "description": "SMRT%20Analysis%20Authorization"
         }
@@ -692,13 +692,21 @@
       },
       "post": {
         "x-auth-type": "Application%20%26%20Application%20User",
-        "x-scope": "smrt-analysis",
+        "x-scope": "analysis",
         "x-throttling-tier": "Unlimited",
         "consumes": [
           "application/json"
         ],
         "produces": [
           "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
         ],
         "responses": {
           "201": {},

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobManagerService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobManagerService.scala
@@ -17,6 +17,7 @@ import com.pacbio.secondary.smrtlink.app.SmrtLinkConfigProvider
 import com.pacbio.secondary.smrtlink.models._
 import com.pacbio.secondary.smrtlink.services.jobtypes._
 import spray.httpx.SprayJsonSupport._
+import spray.http.HttpHeaders
 import spray.json._
 import spray.routing._
 import spray.routing.directives.FileAndResourceDirectives
@@ -104,7 +105,10 @@ class JobManagerService(
         path("download") {
           get {
             onSuccess((dbActor ? GetDataStoreFileByUUID(datastoreFileUUID)).mapTo[DataStoreServiceFile]) { file =>
-              getFromFile(file.path)
+              val fn = s"job-${file.jobId}-${file.uuid.toString}-${Paths.get(file.path).toAbsolutePath.getFileName}"
+              respondWithHeader(HttpHeaders.`Content-Disposition`("attachment; filename=" + fn)) {
+                getFromFile(file.path)
+              }
             }
           }
         } ~


### PR DESCRIPTION
Some fixes to API manager issues from yesterday and today.  The analysis scope name changes fixes the job creation failures from yesterday, and the x-auth-type and content-disposition change fix the download failures.