### PR TITLE
Add ScopeService

### DIFF
--- a/extras/wso2/smrtlink_swagger.json
+++ b/extras/wso2/smrtlink_swagger.json
@@ -1231,6 +1231,138 @@
         "x-auth-type": "Application%20%26%20Application%20User"
       }
     },
+    "/scope/run-design": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "Return value"
+          },
+          "204": {
+            "description": "Return value"
+          }
+        },
+        "x-scope": "run-design",
+        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
+    "/scope/run-qc": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "Return value"
+          },
+          "204": {
+            "description": "Return value"
+          }
+        },
+        "x-scope": "run-qc",
+        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
+    "/scope/sample-setup": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "Return value"
+          },
+          "204": {
+            "description": "Return value"
+          }
+        },
+        "x-scope": "sample-setup",
+        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
+    "/scope/data-management": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "Return value"
+          },
+          "204": {
+            "description": "Return value"
+          }
+        },
+        "x-scope": "data-management",
+        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
+    "/scope/analysis": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "Return value"
+          },
+          "204": {
+            "description": "Return value"
+          }
+        },
+        "x-scope": "analysis",
+        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
+    "/scope/iui-basic": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "Return value"
+          },
+          "204": {
+            "description": "Return value"
+          }
+        },
+        "x-scope": "iui-basic",
+        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
+    "/role/Internal/PbAdmin": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "Return value"
+          },
+          "204": {
+            "description": "Return value"
+          }
+        },
+        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
+    "/role/Internal/PbLabTech": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "Return value"
+          },
+          "204": {
+            "description": "Return value"
+          }
+        },
+        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
+    "/role/Internal/PbBioinformatician": {
+      "get": {
+        "responses": {
+          "default": {
+            "description": "Return value"
+          },
+          "204": {
+            "description": "Return value"
+          }
+        },
+        "x-auth-type": "Application%20%26%20Application%20User",
+        "x-throttling-tier": "Unlimited"
+      }
+    },
     "/secondary-analysis/job-manager/jobs/{type}/{job-id}": {
       "get": {
         "responses": {

--- a/smrt-server-base/src/main/scala/com/pacbio/common/app/BaseSmrtServerApp.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/app/BaseSmrtServerApp.scala
@@ -55,6 +55,7 @@ trait CoreProviders extends
   ConfigServiceProvider with
   CommonFilesServiceProvider with
   DiskSpaceServiceProvider with
+  ScopeServiceProvider with
   MimeTypeDetectors with
   SubSystemComponentServiceProvider with
   SubSystemResourceServiceProvider with
@@ -100,6 +101,7 @@ trait AuthenticatedCoreProviders extends
   ConfigServiceProviderx with
   CommonFilesServiceProviderx with
   DiskSpaceServiceProviderx with
+  ScopeServiceProviderx with
   MimeTypeDetectors with
   SubSystemComponentServiceProviderx with
   SubSystemResourceServiceProviderx with

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/ScopeService.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/ScopeService.scala
@@ -1,0 +1,69 @@
+package com.pacbio.common.services
+
+import akka.util.Timeout
+import com.pacbio.common.auth.{AuthenticatorProvider, AuthInfo, Authenticator}
+import com.pacbio.common.dependency.Singleton
+import com.pacbio.common.models._
+import com.pacbio.common.services.PacBioServiceErrors.ResourceNotFoundError
+import spray.httpx.SprayJsonSupport._
+import spray.json._
+import DefaultJsonProtocol._
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits._
+
+class ScopeService(authenticator: Authenticator) extends PacBioService {
+
+  import PacBioJsonProtocol._
+
+  implicit val timeout = Timeout(10.seconds)
+
+  val manifest = PacBioComponentManifest(
+    toServiceId("scope"),
+    "Scope Service",
+    "0.1.0", "Scope Service")
+
+  val routes =
+    pathPrefix("scope") {
+      path(Segment) { s =>
+        get {
+          complete {
+            noContent
+          }
+        }
+      }
+    } ~
+    path("role" / "Internal" / Segment) { r =>
+      val role = Roles.fromString(s"Internal/$r")
+        .getOrElse(throw new ResourceNotFoundError(s"No role named 'Internal/$r'"))
+      get {
+        authenticate(authenticator.wso2Auth) {authInfo: AuthInfo =>
+          authorize(authInfo.hasPermission(role)) {
+            complete {
+              noContent
+            }
+          }
+        }
+      }
+    }
+}
+
+/**
+ * Provides a singleton ScopeService, and also binds it to the set of total services. Concrete providers must mixin a
+ * {{{AuthenticatorProvider}}}.
+ */
+trait ScopeServiceProvider {
+  this: AuthenticatorProvider =>
+
+  val scopeService: Singleton[ScopeService] =
+    Singleton(() => new ScopeService(authenticator())).bindToSet(AllServices)
+}
+
+trait ScopeServiceProviderx {
+  this: AuthenticatorProvider with ServiceComposer =>
+
+  val scopeService: Singleton[ScopeService] =
+    Singleton(() => new ScopeService(authenticator()))
+
+  addService(scopeService)
+}

--- a/smrt-server-base/src/main/scala/com/pacbio/common/services/package.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/services/package.scala
@@ -92,7 +92,7 @@ package object services {
     /**
      * Bundles a service response with the HTTP code 204 (NO CONTENT)
      */
-    def noContent[T](r: T)(implicit m: Marshaller[T]): ToResponseMarshallable = joinCode(NoContent, r)
+    def noContent: ToResponseMarshallable = NoContent
   }
 
   object PacBioServiceErrors {


### PR DESCRIPTION
It seems that WSO2 ignores scope definitions that are not associated with any endpoint.  This is a problem for the 'iui-basic' scope that is not supposed to be associated with any SMRT Link endpoint, but simply used as an indicator of whether the user should be allowed to log into the Insrument UI.

By adding this new service, we can ensure that every scope is associated with an endpoint, and it gives a simple way to check whether a given access token allows access to a given scope.  (As a bonus, I threw in similar endpoints to check whether an access token allows access to a given role.)

I don't know if this is necessarily how we want to solve this problem, but it's an idea.  I'd love to hear thoughts?