### PR TITLE
Better error message for conditional jobs without expected data

### DIFF
--- a/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/client/InternalAnalysisServiceClient.scala
+++ b/smrt-server-analysis-internal/src/main/scala/com/pacbio/secondaryinternal/client/InternalAnalysisServiceClient.scala
@@ -49,12 +49,15 @@ class InternalAnalysisServiceClient(baseUrl: URL, authToken: Option[String] = No
     if (job.state == AnalysisJobStates.SUCCESSFUL) Future { job }
     else Future.failed(throw new Exception(s"Job ${job.id} was not successful ${job.state}. Unable to process conditions"))
 
+  def noDataSetErrorMessage(sc: ServiceCondition, dmt: DataSetMetaType) =
+    s"Failed resolve ${sc.id}'s Entry Point of type $dmt for jobId ${sc.jobId} at ${sc.host}:${sc.port}"
+
   def getFirstDataSetFromEntryPoint(sc: ServiceCondition, eps: Seq[EngineJobEntryPoint], datasetMetaType: DataSetMetaType): Future[UUID] = {
     eps.find(_.datasetType == datasetMetaType.dsId) match {
       case Some(x) => Future {
         x.datasetUUID
       }
-      case _ => Future.failed(throw new Exception(s"Failed resolve ${sc.id}'s Entry Point of type $datasetMetaType for jobId ${sc.jobId} at ${sc.host}:${sc.port}"))
+      case _ => Future.failed(throw new Exception(noDataSetErrorMessage(sc, datasetMetaType)))
     }
   }
 

--- a/smrt-server-analysis-internal/src/test/scala/ConditionalJobSpec.scala
+++ b/smrt-server-analysis-internal/src/test/scala/ConditionalJobSpec.scala
@@ -29,7 +29,7 @@ class ConditionalJobSpec  extends Specification {
         // should not make it past here
         val dmt = DataSetMetaTypes.Subread
         val emptyEntryPoints = List()
-        Try(client.getFirstDataSetFromEntryPoint(sc, emptyEntryPoints, dmt)) match {
+        Try(client.getFirstDataSetFromEntryPoint(emptyEntryPoints, dmt, client.noDataSetErrorMessage(sc, dmt))) match {
           case Failure(t) => t.getMessage mustEqual client.noDataSetErrorMessage(sc, dmt)
         }
       }
@@ -50,7 +50,8 @@ class ConditionalJobSpec  extends Specification {
         val dmt = DataSetMetaTypes.Subread
         val uuid = UUID.randomUUID()
         val validEntryPoints = List(EngineJobEntryPoint(sc.jobId, uuid, dmt.toString))
-        Await.result(client.getFirstDataSetFromEntryPoint(sc, validEntryPoints, dmt), Duration(1, "seconds")) match {
+        val f = client.getFirstDataSetFromEntryPoint(validEntryPoints, dmt, "Shouldn't raise exception")
+        Await.result(f, Duration(1, "seconds")) match {
           case v: UUID => v mustEqual uuid
         }
       }

--- a/smrt-server-analysis-internal/src/test/scala/ConditionalJobSpec.scala
+++ b/smrt-server-analysis-internal/src/test/scala/ConditionalJobSpec.scala
@@ -1,0 +1,36 @@
+import java.net.URL
+
+import akka.actor.ActorSystem
+import com.pacbio.secondary.analysis.datasets.DataSetMetaTypes
+import com.pacbio.secondaryinternal.IOUtils
+import com.pacbio.secondaryinternal.client.InternalAnalysisServiceClient
+import org.specs2.mutable.Specification
+
+import scala.language.reflectiveCalls
+import scala.util.{Try, Failure}
+
+class ConditionalJobSpec  extends Specification {
+
+  "ITG-159 regression test" should {
+    "Incorrect job type should throw a more helpful error message" in {
+      val xs = "condId,host,jobId\nA_30622,smrtlink-beta,30622"
+      val cs = IOUtils.parseConditionCsv(scala.io.Source.fromString(xs))
+      val system = ActorSystem()
+      try {
+        // client for talking to smrtlink-beta
+        val client = new InternalAnalysisServiceClient(new URL("http://smrtlink-mock:1234"))(system)
+        // get the bad entry -- happens to be first
+        val sc = cs.head
+        // should not make it past here
+        val dmt = DataSetMetaTypes.Subread
+        val emptyEntryPoints = List()
+        Try(client.getFirstDataSetFromEntryPoint(sc, emptyEntryPoints, dmt)) match {
+          case Failure(t) => t.getMessage mustEqual client.noDataSetErrorMessage(sc, dmt)
+        }
+      }
+      finally {
+        system.shutdown()
+      }
+    }
+  }
+}

--- a/smrt-server-analysis-internal/src/test/scala/ConditionalJobSpec.scala
+++ b/smrt-server-analysis-internal/src/test/scala/ConditionalJobSpec.scala
@@ -1,13 +1,18 @@
 import java.net.URL
+import java.util.UUID
 
 import akka.actor.ActorSystem
 import com.pacbio.secondary.analysis.datasets.DataSetMetaTypes
+import com.pacbio.secondary.smrtlink.models.EngineJobEntryPoint
 import com.pacbio.secondaryinternal.IOUtils
 import com.pacbio.secondaryinternal.client.InternalAnalysisServiceClient
+import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
 
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 import scala.language.reflectiveCalls
-import scala.util.{Try, Failure}
+import scala.util.{Failure, Success, Try}
 
 class ConditionalJobSpec  extends Specification {
 
@@ -26,6 +31,27 @@ class ConditionalJobSpec  extends Specification {
         val emptyEntryPoints = List()
         Try(client.getFirstDataSetFromEntryPoint(sc, emptyEntryPoints, dmt)) match {
           case Failure(t) => t.getMessage mustEqual client.noDataSetErrorMessage(sc, dmt)
+        }
+      }
+      finally {
+        system.shutdown()
+      }
+    }
+    "Correct job type should work" in {
+      val xs = "condId,host,jobId\nA_30622,smrtlink-beta,30622"
+      val cs = IOUtils.parseConditionCsv(scala.io.Source.fromString(xs))
+      val system = ActorSystem()
+      try {
+        // client for talking to smrtlink-beta
+        val client = new InternalAnalysisServiceClient(new URL("http://smrtlink-mock:1234"))(system)
+        // get the bad entry -- happens to be first
+        val sc = cs.head
+        // should not make it past here
+        val dmt = DataSetMetaTypes.Subread
+        val uuid = UUID.randomUUID()
+        val validEntryPoints = List(EngineJobEntryPoint(sc.jobId, uuid, dmt.toString))
+        Await.result(client.getFirstDataSetFromEntryPoint(sc, validEntryPoints, dmt), Duration(1, "seconds")) match {
+          case v: UUID => v mustEqual uuid
         }
       }
       finally {


### PR DESCRIPTION
CC @evolvedmicrobe, @mpkocher 

Fixes [ITG-159](https://jira.pacificbiosciences.com/browse/ITG-159). See the JIRA ticket, but in short a list of jobs was given where one of the jobs lacked the expected `SubreadSet`. The error message was along the lines of the following.

```
java.lang.Exception: Failed resolve Entry Point type PacBio.DataSet.SubreadSet
```

This PR will change it to be this.

```
Failed resolve A_30622's Entry Point of type PacBio.DataSet.SubreadSet for jobId 30622 at smrtlink-beta:8081
```