### PR TITLE
remove SMRTLink/1.0.0 prefix (there are other prefixes now)

### DIFF
--- a/extras/pbbundler/smrtlink_services_ui/bin/apply-config
+++ b/extras/pbbundler/smrtlink_services_ui/bin/apply-config
@@ -523,7 +523,7 @@ def to_smrt_link_ui_config_d(host, services_port, smrtview_port, service_event_u
     :return: dict conf of SL UI
     """
     smrtview_uri = to_uri(host, smrtview_port)
-    services_uri = to_uri(host, 8243, "SMRTLink/1.0.0", https=True)
+    services_uri = to_uri(host, 8243, "", https=True)
     auth_uri = to_uri(host, 8243, https=True)
 
     d = {"smrt-view": {"default-server": smrtview_uri},


### PR DESCRIPTION
Now that the RemoteUserStoreManagerService API exists alongside the SMRTLink API, the config shouldn't include the `SMRTLink/1.0.0` prefix anymore.

This smrtflow change goes along with this client-side change: http://swarm/reviews/187716

If/when this PR gets merged, I'll update the smrtflow ini and submit that client-side change at the same time.