### PR TITLE
backwards compatibility for EngineJob unmarshalling

### DIFF
--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/datasets/DataSetModels.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/datasets/DataSetModels.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 
 import com.pacbio.secondary.analysis.constants.FileTypes
 import com.pacbio.secondary.analysis.constants.FileTypes.DataSetBaseType
-import com.pacbio.secondary.analysis.jobs.UUIDJsonProtocol
+import com.pacbio.common.models.UUIDJsonProtocol
 import com.pacificbiosciences.pacbiodatasets.{SubreadSet, HdfSubreadSet, AlignmentSet, BarcodeSet, ConsensusReadSet, ConsensusAlignmentSet, ContigSet, ReferenceSet, GmapReferenceSet}
 import com.pacificbiosciences.pacbiodatasets.{DataSetType => XmlDataSetType}
 

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/SecondaryJsonProtocols.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/SecondaryJsonProtocols.scala
@@ -7,7 +7,7 @@ import com.pacbio.secondary.analysis.datasets.DataSetMetaTypes
 import com.pacbio.secondary.analysis.engine.EngineConfig
 import com.pacbio.secondary.analysis.jobs.JobModels._
 import com.pacbio.secondary.analysis.jobtypes._
-import com.pacbio.common.models.UUIDJsonProtocol
+import com.pacbio.common.models.{UUIDJsonProtocol,JodaDateTimeProtocol}
 import org.joda.time.{DateTime => JodaDateTime}
 import spray.json._
 
@@ -50,21 +50,6 @@ trait DataSetMetaTypesProtocol extends DefaultJsonProtocol {
 }
 
 
-// These are borrowed from Base SMRT Server
-trait JodaDateTimeProtocol extends DefaultJsonProtocol {
-
-  implicit object JodaDateTimeFormat extends JsonFormat[JodaDateTime] {
-    def write(obj: JodaDateTime): JsValue = JsString(obj.toString)
-
-
-    def read(json: JsValue): JodaDateTime = json match {
-      case JsString(x) => JodaDateTime.parse(x)
-      case _ => deserializationError("Expected DateTime as JsString")
-    }
-  }
-
-}
-
 // FIXME backwards compatibility for pbservice and older versions of smrtlink -
 // this should be eliminated in favor of the automatic protocol if and when
 // we can get away with it
@@ -74,7 +59,7 @@ trait EngineJobProtocol
     with JodaDateTimeProtocol
     with JobStatesJsonProtocol {
 
-  implicit object EngineJobFormat extends JsonFormat[EngineJob] {
+  implicit object EngineJobFormat extends RootJsonFormat[EngineJob] {
     def write(obj: EngineJob): JsObject = {
       JsObject(
         "id" -> JsNumber(obj.id),

--- a/smrt-analysis/src/test/resources/misc-json/engine_job_01.json
+++ b/smrt-analysis/src/test/resources/misc-json/engine_job_01.json
@@ -1,0 +1,12 @@
+{
+  "name": "Site Acceptance Test",
+  "updatedAt": "2016-02-02T22:31:28.126Z",
+  "path": "/analysis/smrtlink/userdata/jobs_root/000/000003",
+  "state": "SUCCESSFUL",
+  "uuid": "49618fc1-f315-4dfc-b2f4-99db9459f191",
+  "jobTypeId": "pbsmrtpipe",
+  "id": 3,
+  "comment": "from smrtlink version 3.1.1",
+  "createdAt": "2016-02-02T22:31:28.126Z",
+  "jsonSettings": "{\"name\":\"Site Acceptance Test\",\"entryPoints\":[{\"entryId\":\"eid_subread\",\"fileTypeId\":\"PacBio.DataSet.SubreadSet\",\"datasetId\":2},{\"entryId\":\"eid_ref_dataset\",\"fileTypeId\":\"PacBio.DataSet.ReferenceSet\",\"datasetId\":1}],\"workflowOptions\":[],\"taskOptions\":[],\"pipelineId\":\"pbsmrtpipe.pipelines.sa3_sat\"}"
+}

--- a/smrt-analysis/src/test/resources/misc-json/engine_job_02.json
+++ b/smrt-analysis/src/test/resources/misc-json/engine_job_02.json
@@ -1,0 +1,14 @@
+{
+  "name": "Site Acceptance Test",
+  "updatedAt": "2016-02-02T22:31:28.126Z",
+  "path": "/analysis/smrtlink/userdata/jobs_root/000/000003",
+  "state": "SUCCESSFUL",
+  "uuid": "49618fc1-f315-4dfc-b2f4-99db9459f191",
+  "jobTypeId": "pbsmrtpipe",
+  "id": 3,
+  "comment": "from smrtlink version 3.2.0",
+  "createdAt": "2016-02-02T22:31:28.126Z",
+  "jsonSettings": "{\"name\":\"Site Acceptance Test\",\"entryPoints\":[{\"entryId\":\"eid_subread\",\"fileTypeId\":\"PacBio.DataSet.SubreadSet\",\"datasetId\":2},{\"entryId\":\"eid_ref_dataset\",\"fileTypeId\":\"PacBio.DataSet.ReferenceSet\",\"datasetId\":1}],\"workflowOptions\":[],\"taskOptions\":[],\"pipelineId\":\"pbsmrtpipe.pipelines.sa3_sat\"}",
+  "smrtlinkVersion": "3.2.0.187627",
+  "smrtlinkToolsVersion": "3.2.0.187285"
+}

--- a/smrt-analysis/src/test/resources/misc-json/engine_job_03.json
+++ b/smrt-analysis/src/test/resources/misc-json/engine_job_03.json
@@ -1,0 +1,16 @@
+{
+  "name": "Site Acceptance Test",
+  "updatedAt": "2016-02-02T22:31:28.126Z",
+  "path": "/analysis/smrtlink/userdata/jobs_root/000/000003",
+  "state": "SUCCESSFUL",
+  "uuid": "49618fc1-f315-4dfc-b2f4-99db9459f191",
+  "jobTypeId": "pbsmrtpipe",
+  "id": 3,
+  "comment": "from smrtlink version 3.2.0",
+  "createdAt": "2016-02-02T22:31:28.126Z",
+  "createdBy": "root",
+  "jsonSettings": "{\"name\":\"Site Acceptance Test\",\"entryPoints\":[{\"entryId\":\"eid_subread\",\"fileTypeId\":\"PacBio.DataSet.SubreadSet\",\"datasetId\":2},{\"entryId\":\"eid_ref_dataset\",\"fileTypeId\":\"PacBio.DataSet.ReferenceSet\",\"datasetId\":1}],\"workflowOptions\":[],\"taskOptions\":[],\"pipelineId\":\"pbsmrtpipe.pipelines.sa3_sat\"}",
+  "smrtlinkVersion": "3.3.0.187723",
+  "smrtlinkToolsVersion": "3.3.0.187723",
+  "isActive": false
+}

--- a/smrt-analysis/src/test/scala/JsonCompatibilitySpec.scala
+++ b/smrt-analysis/src/test/scala/JsonCompatibilitySpec.scala
@@ -1,0 +1,52 @@
+
+import java.nio.file.Paths
+import java.util.UUID
+
+import com.typesafe.scalalogging.LazyLogging
+import org.specs2.mutable._
+import spray.json._
+import scala.io.Source
+
+import com.pacbio.secondary.analysis.jobs.JobModels._
+import com.pacbio.secondary.analysis.jobs.SecondaryJobJsonProtocol
+
+
+class JsonCompatibilitySpec extends Specification with SecondaryJobJsonProtocol with LazyLogging {
+
+  def getPath(name: String) = Paths.get(getClass.getResource(s"misc-json/$name").toURI)
+
+  "Testing EngineJob unmarshalling" should {
+    "Load 3.1.1 model from JSON" in {
+      val path = getPath("engine_job_01.json")
+      val job = Source.fromFile(path.toFile).getLines.mkString.parseJson.convertTo[EngineJob]
+      job.smrtlinkVersion must beEqualTo(None)
+      job.id must beEqualTo(3)
+      job.isActive must beEqualTo(true)
+      val s = job.toJson
+      val job2 = s.convertTo[EngineJob]
+      job2.isActive must beEqualTo(true)
+      job2.createdBy must beNone
+    }
+    "Load 3.2.0 model from JSON" in {
+      val path = getPath("engine_job_02.json")
+      val job = Source.fromFile(path.toFile).getLines.mkString.parseJson.convertTo[EngineJob]
+      job.smrtlinkVersion.get must beEqualTo("3.2.0.187627")
+      job.id must beEqualTo(3)
+      job.isActive must beEqualTo(true)
+    }
+    "Load 3.3+ model from JSON" in {
+      val path = getPath("engine_job_03.json")
+      val job = Source.fromFile(path.toFile).getLines.mkString.parseJson.convertTo[EngineJob]
+      job.smrtlinkVersion.get must beEqualTo("3.3.0.187723")
+      job.id must beEqualTo(3)
+      job.createdBy.get must beEqualTo("root")
+      job.isActive must beEqualTo(false)
+      val s = job.toJson
+      val job2 = s.convertTo[EngineJob]
+      job2.isActive must beEqualTo(false)
+      job2.smrtlinkVersion.get must beEqualTo("3.3.0.187723")
+      job2.createdAt must beEqualTo(job.createdAt)
+    }
+  }
+
+}

--- a/smrt-common-models/src/main/scala/com/pacbio/common/models/JsonProtocols.scala
+++ b/smrt-common-models/src/main/scala/com/pacbio/common/models/JsonProtocols.scala
@@ -2,6 +2,7 @@ package com.pacbio.common.models
 
 import java.util.UUID
 import spray.json._
+import org.joda.time.{DateTime => JodaDateTime}
 import fommil.sjs.FamilyFormats
 
 trait UUIDJsonProtocol extends DefaultJsonProtocol with FamilyFormats {
@@ -11,6 +12,20 @@ trait UUIDJsonProtocol extends DefaultJsonProtocol with FamilyFormats {
     def read(json: JsValue): UUID = json match {
       case JsString(x) => UUID.fromString(x)
       case _ => deserializationError("Expected UUID as JsString")
+    }
+  }
+}
+
+trait JodaDateTimeProtocol extends DefaultJsonProtocol with FamilyFormats {
+  import PacBioDateTimeFormat.DATE_TIME_FORMAT
+
+  implicit object JodaDateTimeFormat extends JsonFormat[JodaDateTime] {
+    def write(obj: JodaDateTime): JsValue = JsString(obj.toString(DATE_TIME_FORMAT))
+
+
+    def read(json: JsValue): JodaDateTime = json match {
+      case JsString(x) => JodaDateTime.parse(x, DATE_TIME_FORMAT)
+      case _ => deserializationError("Expected DateTime as JsString")
     }
   }
 }

--- a/smrt-common-models/src/main/scala/com/pacbio/common/models/PacBioDateTimeFormat.scala
+++ b/smrt-common-models/src/main/scala/com/pacbio/common/models/PacBioDateTimeFormat.scala
@@ -1,0 +1,34 @@
+
+package com.pacbio.common.models
+
+import com.typesafe.config.ConfigFactory
+import org.joda.time.{DateTimeZone => JodaDateTimeZone, DateTime => JodaDateTime}
+import org.joda.time.format.{DateTimeFormatter => JodaDateTimeFormatter, ISODateTimeFormat}
+import scala.util.control.NonFatal
+
+/**
+ * Provides standardized (ISO) formats for dates, times, and datetimes. All formats use the local
+ * time zone, as provided by the system properties.
+ */
+object PacBioDateTimeFormat {
+  // TODO(smcclellan): Consider removing all uses of local time zones, and use UTC everywhere?
+  lazy val TIME_ZONE: JodaDateTimeZone = {
+    val configPath = "user.timezone"
+    val defaultZone: JodaDateTimeZone = JodaDateTimeZone.UTC
+
+    val conf = ConfigFactory.load()
+    if (conf.hasPath(configPath))
+      try {
+        JodaDateTimeZone.forID(conf.getString(configPath))
+      } catch {
+        case NonFatal(_) => defaultZone
+      }
+    else defaultZone
+  }
+
+  val DATE_TIME_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.dateTime().withZone(TIME_ZONE)
+  val DATE_TIME_NO_MILLIS_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.dateTimeNoMillis().withZone(TIME_ZONE)
+  val DATE_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.date().withZone(TIME_ZONE)
+  val TIME_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.time().withZone(TIME_ZONE)
+  val TIME_NO_MILLIS_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.timeNoMillis().withZone(TIME_ZONE)
+}

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/client/ServiceAccessLayer.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/client/ServiceAccessLayer.scala
@@ -31,7 +31,7 @@ import java.lang.System
 import java.nio.file.Path
 
 
-object AnalysisClientJsonProtocol extends SmrtLinkJsonProtocols with SecondaryAnalysisJsonProtocols
+object AnalysisClientJsonProtocol extends SmrtLinkJsonProtocols
 
 class AnalysisServiceAccessLayer(baseUrl: URL, authToken: Option[String] = None)
     (implicit actorSystem: ActorSystem)

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/models/SecondaryAnalysisJsonProtocols.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/models/SecondaryAnalysisJsonProtocols.scala
@@ -25,14 +25,6 @@ trait ReportViewRuleProtocol extends DefaultJsonProtocol {
 
 trait SecondaryAnalysisJsonProtocols extends SmrtLinkJsonProtocols with ReportJsonProtocol with ReportViewRuleProtocol with FamilyFormats {
 
-  // We bring the required imports from SecondaryJobJsonProtocols like this, as opposed to using it as a mixin, because
-  // of namespace conflicts.
-  implicit val pipelineTemplateFormat = SecondaryJobProtocols.PipelineTemplateFormat
-  implicit val pipelineTemplateViewRule = SecondaryJobProtocols.pipelineTemplateViewRule
-  implicit val importDataStoreOptionsFormat = SecondaryJobProtocols.importDataStoreOptionsFormat
-  implicit val importConvertFastaOptionsFormat = SecondaryJobProtocols.importConvertFastaOptionsFormat
-  implicit val movieMetadataToHdfSubreadOptionsFormat = SecondaryJobProtocols.movieMetadataToHdfSubreadOptionsFormat
-
   // Jobs
   implicit val jobEventRecordFormat = jsonFormat2(JobEventRecord)
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/actors/CleanupDao.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/actors/CleanupDao.scala
@@ -11,7 +11,7 @@ import com.pacbio.common.dependency.Singleton
 import com.pacbio.common.logging.{LogResources, Logger, LoggerFactory, LoggerFactoryProvider}
 import com.pacbio.common.models._
 import com.pacbio.common.services.PacBioServiceErrors
-import com.pacbio.common.time.{Clock, ClockProvider, PacBioDateTimeFormat}
+import com.pacbio.common.time.{Clock, ClockProvider}
 import com.pacbio.secondary.analysis.engine.CommonMessages.MessageResponse
 import org.joda.time.{DateTime => JodaDateTime, Duration => JodaDuration}
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/models/JsonProtocols.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/models/JsonProtocols.scala
@@ -1,6 +1,5 @@
 package com.pacbio.common.models
 
-import com.pacbio.common.time.PacBioDateTimeFormat
 import com.pacbio.secondary.analysis.engine.CommonMessages.MessageResponse
 import org.joda.time.{DateTime => JodaDateTime}
 import spray.json._
@@ -8,19 +7,6 @@ import fommil.sjs.FamilyFormats
 
 import scala.concurrent.duration.Duration
 
-trait JodaDateTimeProtocol extends DefaultJsonProtocol with FamilyFormats {
-  import PacBioDateTimeFormat.DATE_TIME_FORMAT
-
-  implicit object JodaDateTimeFormat extends JsonFormat[JodaDateTime] {
-    def write(obj: JodaDateTime): JsValue = JsString(obj.toString(DATE_TIME_FORMAT))
-
-
-    def read(json: JsValue): JodaDateTime = json match {
-      case JsString(x) => JodaDateTime.parse(x, DATE_TIME_FORMAT)
-      case _ => deserializationError("Expected DateTime as JsString")
-    }
-  }
-}
 
 trait HealthProtocols extends DefaultJsonProtocol with FamilyFormats {
 

--- a/smrt-server-base/src/main/scala/com/pacbio/common/time/Clock.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/time/Clock.scala
@@ -1,6 +1,7 @@
 package com.pacbio.common.time
 
 import com.pacbio.common.dependency.Singleton
+import com.pacbio.common.models.PacBioDateTimeFormat
 import org.joda.time.{DateTime => JodaDateTime, Instant => JodaInstant}
 
 /**

--- a/smrt-server-base/src/main/scala/com/pacbio/common/time/PacBioDateTimeFormat.scala
+++ b/smrt-server-base/src/main/scala/com/pacbio/common/time/PacBioDateTimeFormat.scala
@@ -6,32 +6,7 @@ import org.joda.time.format.{DateTimeFormatter => JodaDateTimeFormatter, ISODate
 import slick.driver.SQLiteDriver.api._
 import scala.util.control.NonFatal
 
-/**
- * Provides standardized (ISO) formats for dates, times, and datetimes. All formats use the local
- * time zone, as provided by the system properties.
- */
-object PacBioDateTimeFormat {
-  // TODO(smcclellan): Consider removing all uses of local time zones, and use UTC everywhere?
-  lazy val TIME_ZONE: JodaDateTimeZone = {
-    val configPath = "user.timezone"
-    val defaultZone: JodaDateTimeZone = JodaDateTimeZone.UTC
-
-    val conf = ConfigFactory.load()
-    if (conf.hasPath(configPath))
-      try {
-        JodaDateTimeZone.forID(conf.getString(configPath))
-      } catch {
-        case NonFatal(_) => defaultZone
-      }
-    else defaultZone
-  }
-
-  val DATE_TIME_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.dateTime().withZone(TIME_ZONE)
-  val DATE_TIME_NO_MILLIS_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.dateTimeNoMillis().withZone(TIME_ZONE)
-  val DATE_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.date().withZone(TIME_ZONE)
-  val TIME_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.time().withZone(TIME_ZONE)
-  val TIME_NO_MILLIS_FORMAT: JodaDateTimeFormatter = ISODateTimeFormat.timeNoMillis().withZone(TIME_ZONE)
-}
+import com.pacbio.common.models.PacBioDateTimeFormat
 
 /**
  * Implicit mapped column type that stores Joda DateTime objects as Longs (millis since epoch).

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/DataModelParser.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/DataModelParser.scala
@@ -8,7 +8,7 @@ import javax.xml.datatype.XMLGregorianCalendar
 
 import com.pacbio.common.dependency.Singleton
 import com.pacbio.common.services.PacBioServiceErrors.UnprocessableEntityError
-import com.pacbio.common.time.PacBioDateTimeFormat
+import com.pacbio.common.models.PacBioDateTimeFormat
 import com.pacificbiosciences.pacbiobasedatamodel.SupportedAcquisitionStates
 import com.pacificbiosciences.pacbiodatamodel.PacBioDataModel
 import org.joda.time.{DateTime => JodaDateTime}

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/SmrtLinkJsonProtocols.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/SmrtLinkJsonProtocols.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Paths, Path}
 import com.pacbio.common.models._
 import com.pacbio.secondary.analysis.datasets.DataSetMetaTypes._
 import com.pacbio.secondary.analysis.jobs.JobModels.DataStoreJobFile
-import com.pacbio.secondary.analysis.jobs.{JobStatesJsonProtocol, SecondaryJobProtocols}
+import com.pacbio.secondary.analysis.jobs.{JobStatesJsonProtocol, SecondaryJobJsonProtocol}
 import com.pacbio.secondary.analysis.jobtypes.MergeDataSetOptions
 import com.pacificbiosciences.pacbiobasedatamodel.{SupportedRunStates, SupportedAcquisitionStates}
 import spray.json._
@@ -100,7 +100,7 @@ trait EntryPointProtocols extends DefaultJsonProtocol with UUIDJsonProtocol {
 
 trait SmrtLinkJsonProtocols
   extends BaseJsonProtocol
-  with JobStatesJsonProtocol
+  with SecondaryJobJsonProtocol
   with ServiceTaskOptionProtocols
   with SupportedRunStatesProtocols
   with SupportedAcquisitionStatesProtocols
@@ -122,20 +122,6 @@ trait SmrtLinkJsonProtocols
   implicit val pbRegistryResourceCreateFormat = jsonFormat3(RegistryResourceCreate)
   implicit val pbRegistryResourceUpdateFormat = jsonFormat2(RegistryResourceUpdate)
   implicit val pbRegistryProxyRequestFormat = jsonFormat5(RegistryProxyRequest)
-
-
-  // TODO(smcclellan): We should fix this by having pacbio-secondary import formats from base-smrt-server.
-  // These should be acquired by mixing in SecondaryJobJsonProtocol, but we can't because of UUIDFormat and
-  // DateTimeFormat collisions.
-  implicit val engineJobFormat = SecondaryJobProtocols.EngineJobFormat
-  implicit val engineConfigFormat = SecondaryJobProtocols.engineConfigFormat
-  implicit val datastoreFileFormat = SecondaryJobProtocols.datastoreFileFormat
-  implicit val datastoreFormat = SecondaryJobProtocols.datastoreFormat
-  implicit val entryPointFormat = SecondaryJobProtocols.entryPointFormat
-  implicit val importDataSetOptionsFormat = SecondaryJobProtocols.importDataSetOptionsFormat
-  implicit val jobEventFormat = SecondaryJobProtocols.jobEventFormat
-  implicit val simpleDevJobOptionsFormat  = SecondaryJobProtocols.simpleDevJobOptionsFormat
-
 
   implicit val jobTypeFormat = jsonFormat2(JobTypeEndPoint)
 

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/SmrtLinkJsonProtocols.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/SmrtLinkJsonProtocols.scala
@@ -127,7 +127,7 @@ trait SmrtLinkJsonProtocols
   // TODO(smcclellan): We should fix this by having pacbio-secondary import formats from base-smrt-server.
   // These should be acquired by mixing in SecondaryJobJsonProtocol, but we can't because of UUIDFormat and
   // DateTimeFormat collisions.
-  implicit val engineJobFormat = SecondaryJobProtocols.engineJobFormat
+  implicit val engineJobFormat = SecondaryJobProtocols.EngineJobFormat
   implicit val engineConfigFormat = SecondaryJobProtocols.engineConfigFormat
   implicit val datastoreFileFormat = SecondaryJobProtocols.datastoreFileFormat
   implicit val datastoreFormat = SecondaryJobProtocols.datastoreFormat


### PR DESCRIPTION
@mpkocher @smcclellan7 please review; in the process I did a bunch of refactoring that I had thought was necessary at the time - this eliminates the conflict between our custom JSON protocols and allows us to use simple inheritance.  On the other hand, I don't think this refactoring is actually necessary to get my new protocol to work (changing `JsonFormat` to `RootJsonFormat` in `EngineJobProtocol` was what I really needed).  Your call whether we go with these changes or stick to the more limited solution.