### PR TITLE
[SL-431] set backend port

### DIFF
--- a/extras/pbbundler/smrtlink_services_ui/bin/start
+++ b/extras/pbbundler/smrtlink_services_ui/bin/start
@@ -134,4 +134,12 @@ echo "Starting up ENTERPRISE wso2 API Manager"
 bash $ws02_dir/bin/wso2server.sh --start
 echo "started up WSO2 API Manager"
 
+java -cp $__root/$SERVICES_JAR_NAME \
+     -Dconfig.file=$__root/prod.conf \
+     com.pacbio.secondary.smrtserver.tools.AmClientApp \
+     set-api --swagger-resource /smrtlink_swagger.json \
+     --app-config $tomcat_dir/webapps/ROOT/app-config.json \
+     --user admin --pass admin --host localhost \
+     && echo "configured API Manager for smrtlink backend"
+
 echo "Completed starting the SMRT Link services and tomcat UI server"

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/AmClient.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/AmClient.scala
@@ -6,6 +6,7 @@ import java.nio.file.{Files, Path}
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.util.Try
 
 import akka.actor.ActorSystem
 import akka.util.Timeout
@@ -60,13 +61,12 @@ object AmClientParser {
   // smrt-server-analysis/target/pack/bin/amclient set-api --target http://localhost:8090/ --swagger-resource /smrtlink_swagger.json --app-config ~/p4/ui/main/apps/smrt-link/src/app-config.json --user admin --pass admin --host login14-biofx02 --port-offset 10
 
   val conf = ConfigFactory.load()
-  val target = if (conf.hasPath("pb-services.host") && conf.hasPath("pb-services.port")) {
-    val backendHost = conf.getString("pb-services.host")
-    val backendPort = conf.getString("pb-services.port")
-    Some(s"http://${backendHost}:${backendPort}/")
-  } else {
-    None
-  }
+
+  val targetx = for {
+    host <- Try { conf.getString("pb-services.host") }
+    port <- Try { conf.getInt("pb-services.port")}
+  } yield s"http://$host:$port/"
+  val target = targetx.toOption
 
   case class CustomConfig(
     mode: AmClientModes.Mode = AmClientModes.UNKNOWN,

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/ApiManagerAccessLayer.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/ApiManagerAccessLayer.scala
@@ -20,7 +20,6 @@ import spray.httpx.marshalling.BasicMarshallers._
 import spray.httpx.SprayJsonSupport
 import spray.json._
 
-import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 
 import org.wso2.carbon.apimgt.rest.api.store


### PR DESCRIPTION
This sets the backend port and the swagger at services start time, fixing SL-431 and relieving us from having to update the wso2 zip when we add new endpoints to the swagger.