### PR TITLE
[SL-619] Report migration errors and recreate job_events index

### DIFF
--- a/smrt-server-link/src/main/scala/db/migration/SlickMigration.scala
+++ b/smrt-server-link/src/main/scala/db/migration/SlickMigration.scala
@@ -46,7 +46,7 @@ trait SlickMigration { self: JdbcMigration =>
   override final def migrate(conn: Connection): Unit = {
     val db = new UnmanagedDatabase(conn)
     try {
-      Await.ready(slickMigrate(db), Duration.Inf)
+      Await.result(slickMigrate(db), Duration.Inf)
     } finally {
       db.close()
     }
@@ -60,7 +60,7 @@ trait SlickCallback extends BaseFlywayCallback {
   override final def afterBaseline(conn: Connection): Unit = {
     val db = new UnmanagedDatabase(conn)
     try {
-      Await.ready(slickAfterBaseline(db), Duration.Inf)
+      Await.result(slickAfterBaseline(db), Duration.Inf)
     } finally {
       db.close()
     }

--- a/smrt-server-link/src/main/scala/db/migration/V17__AddIndexToEngineJobs.scala
+++ b/smrt-server-link/src/main/scala/db/migration/V17__AddIndexToEngineJobs.scala
@@ -23,17 +23,7 @@ class V17__AddIndexToEngineJobs extends JdbcMigration with SlickMigration {
   override def slickMigrate(db: DatabaseDef): Future[Any] = {
     db.run(DBIO.seq(
       sqlu"create index engine_jobs_uuid on engine_jobs (uuid)",
-      sqlu"create index engine_jobs_job_type on engine_jobs (job_type_id)",
-      sqlu"create index engine_jobs_datasets_job_id on engine_jobs_datasets (job_id)",
-      sqlu"create index job_events_job_id on job_events (job_id)",
-      sqlu"create index dataset_metadata_uuid on dataset_metadata (uuid)",
-      sqlu"create index dataset_metadata_project_id on dataset_metadata (project_id)",
-      sqlu"create index datastore_files_uuid on datastore_files (uuid)",
-      sqlu"create index datastore_files_job_id on datastore_files (job_id)",
-      sqlu"create index datastore_files_job_uuid on datastore_files (job_uuid)",
-      sqlu"create index projects_users_login on projects_users (login)",
-      sqlu"create index projects_users_project_id on projects_users (project_id)",
-      sqlu"create index collection_metadata_run_id on collection_metadata (run_id)"
+      sqlu"create index engine_jobs_job_type on engine_jobs (job_type_id)"
     ))
   }
 

--- a/smrt-server-link/src/main/scala/db/migration/V23__JobEventsIndex.scala
+++ b/smrt-server-link/src/main/scala/db/migration/V23__JobEventsIndex.scala
@@ -1,0 +1,16 @@
+package db.migration
+
+import scala.concurrent.Future
+
+import slick.driver.SQLiteDriver.api._
+import slick.jdbc.JdbcBackend.DatabaseDef
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration
+
+class V23__JobEventsIndex extends JdbcMigration with SlickMigration {
+
+  override def slickMigrate(db: DatabaseDef): Future[Any] = {
+    db.run(sqlu"create index job_events_job_id on job_events (job_id)")
+  }
+
+}

--- a/smrt-server-link/src/main/scala/db/migration/V8__JobUser.scala
+++ b/smrt-server-link/src/main/scala/db/migration/V8__JobUser.scala
@@ -8,13 +8,7 @@ import slick.jdbc.JdbcBackend.DatabaseDef
 import scala.concurrent.Future
 
 class V8__JobUser extends JdbcMigration with SlickMigration {
-  override def slickMigrate(db: DatabaseDef): Future[Any] = db.run {
-    // scalastyle:off
-    SimpleDBIO {
-      _.connection.prepareCall(
-        """
-alter table engine_jobs add column "created_by" varchar(254)
-""").execute
-    }
+  override def slickMigrate(db: DatabaseDef): Future[Any] = {
+    db.run(sqlu"alter table engine_jobs add column 'created_by' varchar(254)")
   }
 }

--- a/smrt-server-link/src/test/scala/DatabaseSpec.scala
+++ b/smrt-server-link/src/test/scala/DatabaseSpec.scala
@@ -23,7 +23,7 @@ class DatabaseSpec extends Specification with Specs2RouteTest with NoTimeConvers
   import JobModels._
   import TableModels._
 
-  val EXPECTED_MIGRATIONS = 22
+  val EXPECTED_MIGRATIONS = 23
 
   object TestProvider extends TestDalProvider with FakeClockProvider {
     override val db: Singleton[Database] = Singleton(() => {


### PR DESCRIPTION
We used to swallow migration exceptions in an Await.ready.  This changes the `ready` to a `result` so that exceptions propagate and get reported.  But that change means that the V17 migration that was generating an exception would stop the migration process.

So this also changes the V17 migration to only include the changes that were successfully made, before it hit the exception.  Changing a past migration that has been applied on various instances is something I would ordinarily say was a no-no, but I think this is a special case.  The effect of the new, shorter V17 is the same as the effect of the old V17; only the statement that resulted in an error (and the subsequent statements, which weren't getting run) have been removed.

It also re-adds the index on job_events.