### PR TITLE
[SL-582] re-add job events index, remove runnablejob before callback, bump timeouts

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 SHELL=/bin/bash
 STRESS_RUNS=1
 SOURCE_DB=test-data/smrtserver-testdata/database/latest
+STRESS_NAME=run
 
 clean:
 	rm -f secondary-smrt-server*.log
@@ -108,7 +109,7 @@ validate-resources: validate-report-view-rules validate-pipeline-view-rules
 # e.g., make full-stress-run STRESS_RUNS=2 SOURCE_DB=~/analysis_services_beta_3.1.1.db
 full-stress-run: test-data/smrtserver-testdata $(SOURCE_DB)
 	@for i in `seq 1 $(STRESS_RUNS)`; do \
-	    RUN=run-$$(date +%s) && \
+	    RUN=$(STRESS_NAME)-$$(date +%F-%T) && \
 	    RUNDIR=test-output/stress-runs && \
 	    OUTDIR=$$RUNDIR/$$RUN && \
 	    mkdir -p $$OUTDIR && \
@@ -118,8 +119,8 @@ full-stress-run: test-data/smrtserver-testdata $(SOURCE_DB)
 	    rm -rf smrt-server-analysis/jobs-root/*; \
 	    sbt smrt-server-analysis/compile && \
 	    SERVERPID=$$(bash -i -c "sbt -no-colors \"smrt-server-analysis/run --log-file $(CURDIR)/$$OUTDIR/secondary-smrt-server.log\" > $$OUTDIR/smrt-server-analysis.out 2> $$OUTDIR/smrt-server-analysis.err & echo \$$!") && \
-	    sleep 30 && \
-	    ./stress.py --profile $$OUTDIR/profile.json > $$OUTDIR/stress.out 2> $$OUTDIR/stress.err ; \
+	    sleep 240 && \
+	    ./stress.py -x 10 --nprocesses 20 --profile $$OUTDIR/profile.json > $$OUTDIR/stress.out 2> $$OUTDIR/stress.err ; \
 	    sleep 2 ; \
 	    pkill -g $$SERVERPID ; \
 	    sleep 2 ; \

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/JobExecutor.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/JobExecutor.scala
@@ -124,7 +124,7 @@ class SimpleJobRunner extends JobRunner with timeUtils {
  */
 class SimpleAndImportJobRunner(dsActor: ActorRef) extends JobRunner with timeUtils{
 
-  implicit val timeout = Timeout(10.seconds)
+  implicit val timeout = Timeout(30.seconds)
 
   private def importDataStoreFile(ds: DataStoreFile, jobUUID: UUID)(implicit ec: ExecutionContext): Future[String] = {
     if (ds.isChunked) {

--- a/smrt-server-analysis/src/main/resources/application.conf
+++ b/smrt-server-analysis/src/main/resources/application.conf
@@ -148,4 +148,7 @@ spray.can {
       max-content-length: 64M
     }
   }
+  server {
+    registration-timeout: 10 s
+  }
 }

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/client/ServiceAccessLayer.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/client/ServiceAccessLayer.scala
@@ -245,7 +245,7 @@ class AnalysisServiceAccessLayer(baseUrl: URL, authToken: Option[String] = None)
     var exitFlag = true
     var nIterations = 0
     val sleepTime = 5000
-    val requestTimeOut = 10.seconds
+    val requestTimeOut = 30.seconds
     var runningJob: Option[EngineJob] = None
     val tStart = java.lang.System.currentTimeMillis() / 1000.0
 

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/PbService.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/PbService.scala
@@ -374,7 +374,7 @@ class PbService (val sal: AnalysisServiceAccessLayer,
   import CommonModels._
   import CommonModelImplicits._
 
-  protected val TIMEOUT = 10 seconds
+  protected val TIMEOUT = 30 seconds
   private lazy val entryPointsLookup = Map(
     "PacBio.DataSet.SubreadSet" -> "eid_subread",
     "PacBio.DataSet.ReferenceSet" -> "eid_ref_dataset",

--- a/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
@@ -194,7 +194,7 @@ class Database(dbURI: String) {
             case x => Future { listeners.foreach(_.success(code, stacktrace, x)) }
           }
         }
-        val toreturn = Await.result(f, 12345 milliseconds) // TODO: config via param
+        val toreturn = Await.result(f, 23456 milliseconds) // TODO: config via param
         // track RDBMS execution timing
         val endRDMS: Long = if (dbug) System.currentTimeMillis() else 0
         if (dbug) Future { listeners.foreach(_.dbDone(startRDMS, endRDMS, code, stacktrace)) }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -282,13 +282,14 @@ trait JobDataStore extends JobEngineDaoComponent with LazyLogging {
   def getNextRunnableJob: Future[Either[NoAvailableWorkError, RunnableJob]] = {
     val noWork = NoAvailableWorkError("No Available work to run.")
     _runnableJobs.values.find(_.state == AnalysisJobStates.CREATED) match {
-      case Some(job) =>
+      case Some(job) => {
+        _runnableJobs.remove(job.job.uuid)
         getJobById(job.id).map {
           case Some(j) =>
-            _runnableJobs.remove(j.uuid)
             Right(RunnableJob(job.job, j.state))
           case None => Left(noWork)
         }
+      }
       case None => Future(Left(noWork))
     }
   }
@@ -298,13 +299,14 @@ trait JobDataStore extends JobEngineDaoComponent with LazyLogging {
     _runnableJobs.values.find((rj) =>
       rj.state == AnalysisJobStates.CREATED &&
       jobTypeFilter(rj.job.jobOptions.toJob.jobTypeId)) match {
-      case Some(job) =>
+      case Some(job) => {
+        _runnableJobs.remove(job.job.uuid)
         getJobById(job.id).map {
           case Some(j) =>
-            _runnableJobs.remove(j.uuid)
             Right(RunnableJobWithId(job.id, job.job, j.state))
           case None => Left(noWork)
         }
+      }
       case None => Future(Left(noWork))
     }
   }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobService.scala
@@ -55,7 +55,7 @@ trait JobService
   with Directives
   with JobServiceConstants {
 
-  implicit val timeout = Timeout(20.seconds)
+  implicit val timeout = Timeout(30.seconds)
 
   import SmrtLinkJsonProtocols._
 

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/jobtypes/ValidateImportDataSetUtils.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/jobtypes/ValidateImportDataSetUtils.scala
@@ -21,7 +21,7 @@ import Scalaz._
 
 trait ValidateImportDataSetUtils {
 
-  implicit val timeout = Timeout(8.seconds)
+  implicit val timeout = Timeout(12.seconds)
 
   type ValidationErrorMsg = String
 

--- a/smrt-server-link/src/main/scala/db/migration/SlickMigration.scala
+++ b/smrt-server-link/src/main/scala/db/migration/SlickMigration.scala
@@ -46,7 +46,7 @@ trait SlickMigration { self: JdbcMigration =>
   override final def migrate(conn: Connection): Unit = {
     val db = new UnmanagedDatabase(conn)
     try {
-      Await.ready(slickMigrate(db), Duration.Inf)
+      Await.result(slickMigrate(db), Duration.Inf)
     } finally {
       db.close()
     }
@@ -60,7 +60,7 @@ trait SlickCallback extends BaseFlywayCallback {
   override final def afterBaseline(conn: Connection): Unit = {
     val db = new UnmanagedDatabase(conn)
     try {
-      Await.ready(slickAfterBaseline(db), Duration.Inf)
+      Await.result(slickAfterBaseline(db), Duration.Inf)
     } finally {
       db.close()
     }

--- a/smrt-server-link/src/main/scala/db/migration/V17__AddIndexToEngineJobs.scala
+++ b/smrt-server-link/src/main/scala/db/migration/V17__AddIndexToEngineJobs.scala
@@ -23,17 +23,7 @@ class V17__AddIndexToEngineJobs extends JdbcMigration with SlickMigration {
   override def slickMigrate(db: DatabaseDef): Future[Any] = {
     db.run(DBIO.seq(
       sqlu"create index engine_jobs_uuid on engine_jobs (uuid)",
-      sqlu"create index engine_jobs_job_type on engine_jobs (job_type_id)",
-      sqlu"create index engine_jobs_datasets_job_id on engine_jobs_datasets (job_id)",
-      sqlu"create index job_events_job_id on job_events (job_id)",
-      sqlu"create index dataset_metadata_uuid on dataset_metadata (uuid)",
-      sqlu"create index dataset_metadata_project_id on dataset_metadata (project_id)",
-      sqlu"create index datastore_files_uuid on datastore_files (uuid)",
-      sqlu"create index datastore_files_job_id on datastore_files (job_id)",
-      sqlu"create index datastore_files_job_uuid on datastore_files (job_uuid)",
-      sqlu"create index projects_users_login on projects_users (login)",
-      sqlu"create index projects_users_project_id on projects_users (project_id)",
-      sqlu"create index collection_metadata_run_id on collection_metadata (run_id)"
+      sqlu"create index engine_jobs_job_type on engine_jobs (job_type_id)"
     ))
   }
 

--- a/smrt-server-link/src/main/scala/db/migration/V23__JobEventsIndex.scala
+++ b/smrt-server-link/src/main/scala/db/migration/V23__JobEventsIndex.scala
@@ -1,0 +1,16 @@
+package db.migration
+
+import scala.concurrent.Future
+
+import slick.driver.SQLiteDriver.api._
+import slick.jdbc.JdbcBackend.DatabaseDef
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration
+
+class V23__JobEventsIndex extends JdbcMigration with SlickMigration {
+
+  override def slickMigrate(db: DatabaseDef): Future[Any] = {
+    db.run(sqlu"create index job_events_job_id on job_events (job_id)")
+  }
+
+}

--- a/smrt-server-link/src/main/scala/db/migration/V8__JobUser.scala
+++ b/smrt-server-link/src/main/scala/db/migration/V8__JobUser.scala
@@ -8,13 +8,7 @@ import slick.jdbc.JdbcBackend.DatabaseDef
 import scala.concurrent.Future
 
 class V8__JobUser extends JdbcMigration with SlickMigration {
-  override def slickMigrate(db: DatabaseDef): Future[Any] = db.run {
-    // scalastyle:off
-    SimpleDBIO {
-      _.connection.prepareCall(
-        """
-alter table engine_jobs add column "created_by" varchar(254)
-""").execute
-    }
+  override def slickMigrate(db: DatabaseDef): Future[Any] = {
+    db.run(sqlu"alter table engine_jobs add column 'created_by' varchar(254)")
   }
 }

--- a/smrt-server-link/src/test/scala/DatabaseSpec.scala
+++ b/smrt-server-link/src/test/scala/DatabaseSpec.scala
@@ -23,7 +23,7 @@ class DatabaseSpec extends Specification with Specs2RouteTest with NoTimeConvers
   import JobModels._
   import TableModels._
 
-  val EXPECTED_MIGRATIONS = 22
+  val EXPECTED_MIGRATIONS = 23
 
   object TestProvider extends TestDalProvider with FakeClockProvider {
     override val db: Singleton[Database] = Singleton(() => {


### PR DESCRIPTION
This is all related to the timeouts we've been seeing--it brings back the index on job events, fixes the race that allowed jobs to get started more than once, and bumps several timeouts.