### PR TITLE
[SL-620] Fix runnablejob race and bump timeouts

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 SHELL=/bin/bash
 STRESS_RUNS=1
 SOURCE_DB=test-data/smrtserver-testdata/database/latest
+STRESS_NAME=run
 
 clean:
 	rm -f secondary-smrt-server*.log
@@ -108,7 +109,7 @@ validate-resources: validate-report-view-rules validate-pipeline-view-rules
 # e.g., make full-stress-run STRESS_RUNS=2 SOURCE_DB=~/analysis_services_beta_3.1.1.db
 full-stress-run: test-data/smrtserver-testdata $(SOURCE_DB)
 	@for i in `seq 1 $(STRESS_RUNS)`; do \
-	    RUN=run-$$(date +%s) && \
+	    RUN=$(STRESS_NAME)-$$(date +%F-%T) && \
 	    RUNDIR=test-output/stress-runs && \
 	    OUTDIR=$$RUNDIR/$$RUN && \
 	    mkdir -p $$OUTDIR && \
@@ -118,8 +119,8 @@ full-stress-run: test-data/smrtserver-testdata $(SOURCE_DB)
 	    rm -rf smrt-server-analysis/jobs-root/*; \
 	    sbt smrt-server-analysis/compile && \
 	    SERVERPID=$$(bash -i -c "sbt -no-colors \"smrt-server-analysis/run --log-file $(CURDIR)/$$OUTDIR/secondary-smrt-server.log\" > $$OUTDIR/smrt-server-analysis.out 2> $$OUTDIR/smrt-server-analysis.err & echo \$$!") && \
-	    sleep 30 && \
-	    ./stress.py --profile $$OUTDIR/profile.json > $$OUTDIR/stress.out 2> $$OUTDIR/stress.err ; \
+	    sleep 360 && \
+	    ./stress.py -x 10 --nprocesses 20 --profile $$OUTDIR/profile.json > $$OUTDIR/stress.out 2> $$OUTDIR/stress.err ; \
 	    sleep 2 ; \
 	    pkill -g $$SERVERPID ; \
 	    sleep 2 ; \

--- a/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/JobExecutor.scala
+++ b/smrt-analysis/src/main/scala/com/pacbio/secondary/analysis/jobs/JobExecutor.scala
@@ -124,7 +124,7 @@ class SimpleJobRunner extends JobRunner with timeUtils {
  */
 class SimpleAndImportJobRunner(dsActor: ActorRef) extends JobRunner with timeUtils{
 
-  implicit val timeout = Timeout(10.seconds)
+  implicit val timeout = Timeout(30.seconds)
 
   private def importDataStoreFile(ds: DataStoreFile, jobUUID: UUID)(implicit ec: ExecutionContext): Future[String] = {
     if (ds.isChunked) {

--- a/smrt-server-analysis/src/main/resources/application.conf
+++ b/smrt-server-analysis/src/main/resources/application.conf
@@ -148,4 +148,7 @@ spray.can {
       max-content-length: 64M
     }
   }
+  server {
+    registration-timeout: 10 s
+  }
 }

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/client/ServiceAccessLayer.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/client/ServiceAccessLayer.scala
@@ -245,7 +245,7 @@ class AnalysisServiceAccessLayer(baseUrl: URL, authToken: Option[String] = None)
     var exitFlag = true
     var nIterations = 0
     val sleepTime = 5000
-    val requestTimeOut = 10.seconds
+    val requestTimeOut = 30.seconds
     var runningJob: Option[EngineJob] = None
     val tStart = java.lang.System.currentTimeMillis() / 1000.0
 

--- a/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/PbService.scala
+++ b/smrt-server-analysis/src/main/scala/com/pacbio/secondary/smrtserver/tools/PbService.scala
@@ -374,7 +374,7 @@ class PbService (val sal: AnalysisServiceAccessLayer,
   import CommonModels._
   import CommonModelImplicits._
 
-  protected val TIMEOUT = 10 seconds
+  protected val TIMEOUT = 30 seconds
   private lazy val entryPointsLookup = Map(
     "PacBio.DataSet.SubreadSet" -> "eid_subread",
     "PacBio.DataSet.ReferenceSet" -> "eid_ref_dataset",

--- a/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
+++ b/smrt-server-database/src/main/scala/com/pacbio/database/Database.scala
@@ -194,7 +194,7 @@ class Database(dbURI: String) {
             case x => Future { listeners.foreach(_.success(code, stacktrace, x)) }
           }
         }
-        val toreturn = Await.result(f, 12345 milliseconds) // TODO: config via param
+        val toreturn = Await.result(f, 23456 milliseconds) // TODO: config via param
         // track RDBMS execution timing
         val endRDMS: Long = if (dbug) System.currentTimeMillis() else 0
         if (dbug) Future { listeners.foreach(_.dbDone(startRDMS, endRDMS, code, stacktrace)) }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -282,13 +282,14 @@ trait JobDataStore extends JobEngineDaoComponent with LazyLogging {
   def getNextRunnableJob: Future[Either[NoAvailableWorkError, RunnableJob]] = {
     val noWork = NoAvailableWorkError("No Available work to run.")
     _runnableJobs.values.find(_.state == AnalysisJobStates.CREATED) match {
-      case Some(job) =>
+      case Some(job) => {
+        _runnableJobs.remove(job.job.uuid)
         getJobById(job.id).map {
           case Some(j) =>
-            _runnableJobs.remove(j.uuid)
             Right(RunnableJob(job.job, j.state))
           case None => Left(noWork)
         }
+      }
       case None => Future(Left(noWork))
     }
   }
@@ -298,13 +299,14 @@ trait JobDataStore extends JobEngineDaoComponent with LazyLogging {
     _runnableJobs.values.find((rj) =>
       rj.state == AnalysisJobStates.CREATED &&
       jobTypeFilter(rj.job.jobOptions.toJob.jobTypeId)) match {
-      case Some(job) =>
+      case Some(job) => {
+        _runnableJobs.remove(job.job.uuid)
         getJobById(job.id).map {
           case Some(j) =>
-            _runnableJobs.remove(j.uuid)
             Right(RunnableJobWithId(job.id, job.job, j.state))
           case None => Left(noWork)
         }
+      }
       case None => Future(Left(noWork))
     }
   }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/EulaService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/EulaService.scala
@@ -33,7 +33,7 @@ class EulaService(dbActor: ActorRef,  authenticator: Authenticator)//(implicit v
     "EULA Service",
     "0.1.0", "End-User License Agreement Service")
 
-  implicit val timeout = Timeout(20.seconds)
+  implicit val timeout = Timeout(30.seconds)
 
   override val routes =
     pathPrefix("eula") {

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobManagerService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobManagerService.scala
@@ -40,7 +40,7 @@ class JobManagerService(
   import JobsDaoActor._
   import SmrtLinkJsonProtocols._
 
-  override implicit val timeout = Timeout(20.seconds)
+  override implicit val timeout = Timeout(30.seconds)
 
   implicit val routing = RoutingSettings.default
 

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobService.scala
@@ -55,7 +55,7 @@ trait JobService
   with Directives
   with JobServiceConstants {
 
-  implicit val timeout = Timeout(20.seconds)
+  implicit val timeout = Timeout(30.seconds)
 
   import SmrtLinkJsonProtocols._
 

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobsBaseMicroService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/JobsBaseMicroService.scala
@@ -12,7 +12,7 @@ import com.typesafe.scalalogging.LazyLogging
  * Base trait for Jobs services. Adds a prefix to to all endpoints. See {{{JobServiceConstants}}}.
  */
 trait JobsBaseMicroService extends PacBioService with JobServiceConstants with LazyLogging {
-  implicit val timeout = Timeout(20.seconds)
+  implicit val timeout = Timeout(30.seconds)
 
   override def prefixedRoutes = pathPrefix(ROOT_SERVICE_PREFIX) { super.prefixedRoutes }
 }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/SmrtLinkBaseMicroService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/SmrtLinkBaseMicroService.scala
@@ -15,7 +15,7 @@ trait SmrtLinkBaseMicroService extends
 PacBioService with
 SmrtLinkConstants with
 LazyLogging {
-  implicit val timeout = Timeout(20.seconds)
+  implicit val timeout = Timeout(30.seconds)
 
   override def prefixedRoutes = pathPrefix(BASE_PREFIX) { super.prefixedRoutes }
 }

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/jobtypes/ValidateImportDataSetUtils.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/jobtypes/ValidateImportDataSetUtils.scala
@@ -21,7 +21,7 @@ import Scalaz._
 
 trait ValidateImportDataSetUtils {
 
-  implicit val timeout = Timeout(8.seconds)
+  implicit val timeout = Timeout(12.seconds)
 
   type ValidationErrorMsg = String
 


### PR DESCRIPTION
Without this change, the methods to get the next runnable job leave the next runnable in the queue while they search for the job entry in the database.  While that database operation is happening, another worker can ask for a runnable job and get the same job, resulting the in the same job getting run by multiple workers.  And we do see that happen - in the week that 4.0 has been running on alpha, at least two jobs ([5d9fbc6f-0254-4e22-bbd6-c9f6cec64801](http://smrtlink-alpha:8081/secondary-analysis/job-manager/jobs/2144/events) and [29e54346-3764-401e-af5d-433bda54a276](http://smrtlink-alpha:8081/secondary-analysis/job-manager/jobs/1837/events)) have been run twice.

This changes the job removal to happen before the database lookup.  With that change, I no longer see jobs getting run multiple times in the stress test.

This also bumps some timeouts to get clean stress test runs.