### PR TITLE
[SL-637] set heap size for API manager client

### DIFF
--- a/extras/pbbundler/smrtlink_services_ui/bin/start
+++ b/extras/pbbundler/smrtlink_services_ui/bin/start
@@ -135,6 +135,7 @@ bash $ws02_dir/bin/wso2server.sh --start
 echo "started up WSO2 API Manager"
 
 java -cp $__root/$SERVICES_JAR_NAME \
+     -Xmx256m -Xms256m \
      -Dconfig.file=$__root/prod.conf \
      com.pacbio.secondary.smrtserver.tools.AmClientApp \
      set-api --swagger-resource /smrtlink_swagger.json \


### PR DESCRIPTION
This is what let JGI smrtlink start up, with their setup that disabled overcommit and had a virtual memory ulimit.