### PR TITLE
remove extra nesting from project user

### DIFF
--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/actors/JobsDao.scala
@@ -82,9 +82,9 @@ trait ProjectDataStore extends LazyLogging {
     db.run(projects.filter(_.id === projId).result.headOption)
 
   def createProject(projReq: ProjectRequest, ownerLogin: String): Future[Project] = {
-    val owner = ProjectRequestUser(RequestUser(ownerLogin), ProjectUserRole.OWNER)
+    val owner = ProjectRequestUser(ownerLogin, ProjectUserRole.OWNER)
     val members = projReq.members.getOrElse(List())
-    val withOwner = members.filter(_.user.login != ownerLogin) ++ List(owner)
+    val withOwner = members.filter(_.login != ownerLogin) ++ List(owner)
     val requestWithOwner = projReq.copy(members = Some(withOwner))
 
     val now = JodaDateTime.now()
@@ -107,7 +107,7 @@ trait ProjectDataStore extends LazyLogging {
   def setProjectMembers(projId: Int, members: Seq[ProjectRequestUser]): DBIO[Unit] =
     DBIO.seq(
       projectsUsers.filter(_.projectId === projId).delete,
-      projectsUsers ++= members.map(m => ProjectUser(projId, m.user.login, m.role))
+      projectsUsers ++= members.map(m => ProjectUser(projId, m.login, m.role))
     )
 
   def setProjectDatasets(projId: Int, ids: Seq[RequestId]): DBIO[Unit] = {

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/Models.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/Models.scala
@@ -510,7 +510,7 @@ case class Project(
     // isActive: false if the project has been deleted, true otherwise
     isActive: Boolean) {
 
-  def makeFull(datasets: Seq[DataSetMetaDataSet], members: Seq[ProjectUserResponse]): FullProject =
+  def makeFull(datasets: Seq[DataSetMetaDataSet], members: Seq[ProjectRequestUser]): FullProject =
     FullProject(
       id,
       name,
@@ -534,7 +534,7 @@ case class FullProject(
     updatedAt: JodaDateTime,
     isActive: Boolean,
     datasets: Seq[DataSetMetaDataSet],
-    members: Seq[ProjectUserResponse]) {
+    members: Seq[ProjectRequestUser]) {
 
   def asRequest: ProjectRequest =
     ProjectRequest(
@@ -542,7 +542,7 @@ case class FullProject(
       description,
       Some(state),
       Some(datasets.map(ds => RequestId(ds.id))),
-      Some(members.map(u => ProjectRequestUser(RequestUser(u.login), u.role))))
+      Some(members.map(u => ProjectRequestUser(u.login, u.role))))
 }
 
 // the json structures required in client requests are a subset of the
@@ -565,7 +565,6 @@ case class ProjectRequest(
 }
 
 case class RequestId(id: Int)
-case class RequestUser(login: String)
 
 object ProjectUserRole {
   sealed trait ProjectUserRole
@@ -579,13 +578,11 @@ object ProjectUserRole {
       .getOrElse(throw new IllegalArgumentException(s"Unknown project user role $r, acceptable values are $OWNER, $CAN_EDIT, $CAN_VIEW"))
   }
 }
-case class ProjectRequestUser(user: RequestUser, role: ProjectUserRole.ProjectUserRole)
+case class ProjectRequestUser(login: String, role: ProjectUserRole.ProjectUserRole)
 case class ProjectUser(projectId: Int, login: String, role: ProjectUserRole.ProjectUserRole)
 
-case class ProjectUserResponse(login: String, role: ProjectUserRole.ProjectUserRole)
-
 case class UserProjectResponse(role: Option[ProjectUserRole.ProjectUserRole], project: Project)
- 
+
 case class ProjectDatasetResponse(project: Project, dataset: DataSetMetaDataSet, role: Option[ProjectUserRole.ProjectUserRole])
 
 

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/SmrtLinkJsonProtocols.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/models/SmrtLinkJsonProtocols.scala
@@ -162,7 +162,6 @@ trait SmrtLinkJsonProtocols
   implicit val fullProjectFormat: RootJsonFormat[FullProject] = cachedImplicit
   implicit val projectRequestFormat: RootJsonFormat[ProjectRequest] = cachedImplicit
   implicit val projectUserRequestFormat: RootJsonFormat[ProjectRequestUser] = cachedImplicit
-  implicit val projectUserResponseFormat: RootJsonFormat[ProjectUserResponse] = cachedImplicit
 
   implicit val eulaFormat = jsonFormat6(EulaRecord)
   implicit val eulaAcceptanceFormat = jsonFormat4(EulaAcceptance)

--- a/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/ProjectService.scala
+++ b/smrt-server-link/src/main/scala/com/pacbio/secondary/smrtlink/services/ProjectService.scala
@@ -34,7 +34,7 @@ class ProjectService(jobsDao: JobsDao, authenticator: Authenticator)
     for {
       datasets <- jobsDao.getDatasetsByProject(proj.id)
       dbUsers <- jobsDao.getProjectUsers(proj.id)
-      userResponses <- Future(dbUsers.map(u => ProjectUserResponse(u.login, u.role)))
+      userResponses <- Future(dbUsers.map(u => ProjectRequestUser(u.login, u.role)))
     } yield proj.makeFull(datasets, userResponses)
 
   def maybeFullProject(projId: Int): Option[Project] => Future[FullProject] = {

--- a/smrt-server-link/src/test/scala/ProjectSpec.scala
+++ b/smrt-server-link/src/test/scala/ProjectSpec.scala
@@ -82,12 +82,12 @@ with SmrtLinkConstants {
   val newProject2 = ProjectRequest("TestProject2", "Test Description", Some(ProjectState.ACTIVE), None, None)
   val newProject3 = ProjectRequest("TestProject3", "Test Description", Some(ProjectState.ACTIVE), None, None)
 
-  val newUser = ProjectRequestUser(RequestUser(ADMIN_USER_2_LOGIN), ProjectUserRole.CAN_EDIT)
-  val newUser2 = ProjectRequestUser(RequestUser(ADMIN_USER_2_LOGIN), ProjectUserRole.CAN_VIEW)
+  val newUser = ProjectRequestUser(ADMIN_USER_2_LOGIN, ProjectUserRole.CAN_EDIT)
+  val newUser2 = ProjectRequestUser(ADMIN_USER_2_LOGIN, ProjectUserRole.CAN_VIEW)
 
   var newProjId = 0
   var newProjMembers: Seq[ProjectRequestUser] =
-    List(ProjectRequestUser(RequestUser(ADMIN_USER_2_LOGIN), ProjectUserRole.OWNER))
+    List(ProjectRequestUser(ADMIN_USER_2_LOGIN, ProjectUserRole.OWNER))
   var dsCount = 0
   var movingDsId = 0
 
@@ -113,7 +113,7 @@ with SmrtLinkConstants {
       Post(s"/$ROOT_SERVICE_PREFIX/projects", newProject) ~> addHeader(ADMIN_CREDENTIALS_1) ~> totalRoutes ~> check {
         status.isSuccess must beTrue
         val proj = responseAs[FullProject]
-        newProjMembers = proj.members.map(x => ProjectRequestUser(RequestUser(x.login), x.role))
+        newProjMembers = proj.members.map(x => ProjectRequestUser(x.login, x.role))
         newProjId = proj.id
         proj.name === proj.name
         proj.state === ProjectState.CREATED
@@ -258,7 +258,7 @@ with SmrtLinkConstants {
       Get(s"/$ROOT_SERVICE_PREFIX/projects/$newProjId") ~> addHeader(ADMIN_CREDENTIALS_1) ~> totalRoutes ~> check {
         status.isSuccess must beTrue
         val users = responseAs[FullProject].members
-        val user = users.filter(_.login == newUser.user.login).head
+        val user = users.filter(_.login == newUser.login).head
         user.role === newUser.role
       }
 
@@ -269,7 +269,7 @@ with SmrtLinkConstants {
       Get(s"/$ROOT_SERVICE_PREFIX/projects/$newProjId") ~> addHeader(ADMIN_CREDENTIALS_1) ~> totalRoutes ~> check {
         status.isSuccess must beTrue
         val users = responseAs[FullProject].members
-        val user = users.filter(_.login == newUser2.user.login).head
+        val user = users.filter(_.login == newUser2.login).head
         user.role === newUser2.role
       }
     }


### PR DESCRIPTION
We had an extra level of nesting in project member info, but the wso2 changes made it unnecessary because the backend only deals in logins now.  This removes that level of nesting; I'd like to get it in to unblock frontend work on SL-20, and it's fairly contained to project-member-related code, so it shouldn't create merge issues.