### PR TITLE
specify db name in psql examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ initdb
 perl -pi.orig -e "s/#port\s*=\s*(\d+)/port = $PGPORT/" $PGDATA/postgresql.conf
 pg_ctl -l $PGDATA/postgresql.log start
 createdb smrtlinkdb
-psql < extras/db-init.sql # these are for the run services or
-psql < extras/test-db-init.sql # for the test db use in the *Spec.scala tests. The DB tables are drop and the migrations are run before each Spec.
+psql -d smrtlinkdb < extras/db-init.sql # these are for the run services or
+psql -d smrtlinkdb < extras/test-db-init.sql # for the test db use in the *Spec.scala tests. The DB tables are drop and the migrations are run before each Spec.
 export SMRTFLOW_DB_PORT=$PGPORT
 ```
 


### PR DESCRIPTION
By default, psql connects to a database with the same name as your username.  If there isn't a database with that name, you get the `psql: FATAL:  database "mskinner" does not exist` error.  You can avoid the error by specifying a db name on the psql command line.